### PR TITLE
Improved FF function fitting and covariance matrix based uncertainty derivation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 
 # custom
 workdir/*
+
+*.bak*
+*.delme*
+*.init*

--- a/FF_calculation/FF_QCD.py
+++ b/FF_calculation/FF_QCD.py
@@ -164,7 +164,7 @@ def calculation_QCD_FFs(
             ff_hists=[FF_hist.Clone(), FF_hist_up, FF_hist_down],
             bin_edges=process_conf["var_bins"],
             logger=logger,
-            fit_option=process_conf.get("fit_option", ("poly_1")),
+            fit_option=process_conf.get("fit_option", "poly_1"),
         )
 
         plotting.plot_FFs(
@@ -177,6 +177,7 @@ def calculation_QCD_FFs(
             category=split,
             output_path=output_path,
             logger=logger,
+            draw_option=process_conf.get("fit_option", "fit")
         )
 
         if len(split) == 1:

--- a/FF_calculation/FF_QCD.py
+++ b/FF_calculation/FF_QCD.py
@@ -9,7 +9,7 @@ import ROOT
 from io import StringIO
 from wurlitzer import pipes, STDOUT
 import logging
-from typing import Union, Dict, List
+from typing import Union, Dict, List, Any
 
 import helper.ff_functions as func
 import helper.plotting as plotting
@@ -141,7 +141,7 @@ def calculation_QCD_FFs(
             ]:
                 SRlike_hists["data_subtracted"].Add(SRlike_hists[hist], -1)
                 SRlike_hists["data_subtracted_up"].Add(SRlike_hists[hist], -0.93)
-                SRlike_hists["data_subtracted_down"].Add(SRlike_hists[hist], -1.07)
+                SRlike_hists["data_subtracted_down"].Add(SRlike_hists[hist], -1.07)  # TODO: ask whats this magic numbers?
         for hist in ARlike_hists:
             if hist not in [
                 "data",
@@ -269,6 +269,7 @@ def non_closure_correction(
     corr_evaluator: FakeFactorCorrectionEvaluator,
     for_DRtoSR: bool,
     logger: str,
+    **kwargs: Dict[str, Any],
 ) -> Dict[str, np.ndarray]:
     """
     This function calculates non closure corrections for fake factors for QCD.

--- a/FF_calculation/FF_QCD.py
+++ b/FF_calculation/FF_QCD.py
@@ -5,7 +5,6 @@ Function for calculating fake factors for the QCD process
 import array
 import copy
 import logging
-from collections import defaultdict
 from io import StringIO
 from typing import Any, Dict, List, Union
 
@@ -48,8 +47,7 @@ def calculation_QCD_FFs(
     corrlib_expressions = dict()
 
     # get QCD specific config information
-    process_conf = defaultdict(lambda: None, config["target_processes"][process])
-
+    process_conf = config["target_processes"][process]
     split_variables, split_combinations = func.get_split_combinations(
         categories=process_conf["split_categories"]
     )
@@ -165,7 +163,7 @@ def calculation_QCD_FFs(
             ff_hists=[FF_hist.Clone(), FF_hist_up, FF_hist_down],
             bin_edges=process_conf["var_bins"],
             logger=logger,
-            fit_option=process_conf["fit_option"],
+            fit_option=process_conf.get("fit_option", ("poly_1")),
         )
 
         plotting.plot_FFs(

--- a/FF_calculation/FF_QCD.py
+++ b/FF_calculation/FF_QCD.py
@@ -23,6 +23,7 @@ def calculation_QCD_FFs(
     output_path: str,
     process: str,
     logger: str,
+    **kwargs: Dict[str, Any],
 ) -> Dict[str, Union[Dict[str, str], Dict[str, Dict[str, str]]]]:
     """
     This function calculates fake factors for QCD.

--- a/FF_calculation/FF_QCD.py
+++ b/FF_calculation/FF_QCD.py
@@ -4,16 +4,18 @@ Function for calculating fake factors for the QCD process
 
 import array
 import copy
+import logging
+from collections import defaultdict
+from io import StringIO
+from typing import Any, Dict, List, Union
+
 import numpy as np
 import ROOT
-from io import StringIO
-from wurlitzer import pipes, STDOUT
-import logging
-from typing import Union, Dict, List, Any
+from wurlitzer import STDOUT, pipes
 
 import helper.ff_functions as func
 import helper.plotting as plotting
-from helper.ff_evaluators import FakeFactorEvaluator, FakeFactorCorrectionEvaluator
+from helper.ff_evaluators import FakeFactorCorrectionEvaluator, FakeFactorEvaluator
 
 
 def calculation_QCD_FFs(
@@ -46,7 +48,7 @@ def calculation_QCD_FFs(
     corrlib_expressions = dict()
 
     # get QCD specific config information
-    process_conf = config["target_processes"][process]
+    process_conf = defaultdict(lambda: None, config["target_processes"][process])
 
     split_variables, split_combinations = func.get_split_combinations(
         categories=process_conf["split_categories"]
@@ -140,8 +142,8 @@ def calculation_QCD_FFs(
                 "QCD",
             ]:
                 SRlike_hists["data_subtracted"].Add(SRlike_hists[hist], -1)
-                SRlike_hists["data_subtracted_up"].Add(SRlike_hists[hist], -0.93)
-                SRlike_hists["data_subtracted_down"].Add(SRlike_hists[hist], -1.07)  # TODO: ask whats this magic numbers?
+                SRlike_hists["data_subtracted_up"].Add(SRlike_hists[hist], -0.93)  # TODO: ask whats this magic numbers?
+                SRlike_hists["data_subtracted_down"].Add(SRlike_hists[hist], -1.07)  # Answer: Historical reasons
         for hist in ARlike_hists:
             if hist not in [
                 "data",
@@ -163,6 +165,7 @@ def calculation_QCD_FFs(
             ff_hists=[FF_hist.Clone(), FF_hist_up, FF_hist_down],
             bin_edges=process_conf["var_bins"],
             logger=logger,
+            fit_option=process_conf["fit_option"],
         )
 
         plotting.plot_FFs(

--- a/FF_calculation/FF_QCD.py
+++ b/FF_calculation/FF_QCD.py
@@ -165,6 +165,7 @@ def calculation_QCD_FFs(
             bin_edges=process_conf["var_bins"],
             logger=logger,
             fit_option=process_conf.get("fit_option", "poly_1"),
+            limit_and_replace_kwargs=process_conf.get("limit_and_replace_kwargs", {}),  # TODO: Build an config interface for that
         )
 
         plotting.plot_FFs(

--- a/FF_calculation/FF_Wjets.py
+++ b/FF_calculation/FF_Wjets.py
@@ -23,6 +23,7 @@ def calculation_Wjets_FFs(
     sample_paths: List[str],
     output_path: str,
     logger: str,
+    **kwargs: Dict[str, Any],
 ) -> Dict[str, Union[Dict[str, str], Dict[str, Dict[str, str]]]]:
     """
     This function calculates fake factors for W+jets.
@@ -250,6 +251,7 @@ def calculation_Wjets_FFs(
             category=split,
             output_path=output_path,
             logger=logger,
+            draw_option=process_conf.get("fit_option", "fit")
         )
 
         if len(split) == 1:

--- a/FF_calculation/FF_Wjets.py
+++ b/FF_calculation/FF_Wjets.py
@@ -239,6 +239,7 @@ def calculation_Wjets_FFs(
             bin_edges=process_conf["var_bins"],
             logger=logger,
             fit_option=process_conf.get("fit_option", "poly_1"),
+            limit_and_replace_kwargs=process_conf.get("limit_and_replace_kwargs", {}),  # TODO: Build an config interface for that
         )
 
         plotting.plot_FFs(

--- a/FF_calculation/FF_Wjets.py
+++ b/FF_calculation/FF_Wjets.py
@@ -238,7 +238,7 @@ def calculation_Wjets_FFs(
             ff_hists=[FF_hist.Clone(), FF_hist_up, FF_hist_down],
             bin_edges=process_conf["var_bins"],
             logger=logger,
-            fit_option=process_conf.get("fit_option", ("poly_1")),
+            fit_option=process_conf.get("fit_option", "poly_1"),
         )
 
         plotting.plot_FFs(

--- a/FF_calculation/FF_Wjets.py
+++ b/FF_calculation/FF_Wjets.py
@@ -9,7 +9,7 @@ import ROOT
 from io import StringIO
 from wurlitzer import pipes, STDOUT
 import logging
-from typing import Union, Dict, List
+from typing import Union, Dict, List, Any
 
 import helper.ff_functions as func
 import helper.plotting as plotting
@@ -372,6 +372,7 @@ def non_closure_correction(
     corr_evaluator: FakeFactorCorrectionEvaluator,
     for_DRtoSR: bool,
     logger: str,
+    **kwargs: Dict[str, Any],
 ) -> Dict[str, np.ndarray]:
     """
     This function calculates non closure corrections for fake factors for W+jets.

--- a/FF_calculation/FF_Wjets.py
+++ b/FF_calculation/FF_Wjets.py
@@ -4,16 +4,18 @@ Function for calculating fake factors for the W-jets process
 
 import array
 import copy
+import logging
+from collections import defaultdict
+from io import StringIO
+from typing import Any, Dict, List, Union
+
 import numpy as np
 import ROOT
-from io import StringIO
-from wurlitzer import pipes, STDOUT
-import logging
-from typing import Union, Dict, List, Any
+from wurlitzer import STDOUT, pipes
 
 import helper.ff_functions as func
 import helper.plotting as plotting
-from helper.ff_evaluators import FakeFactorEvaluator, FakeFactorCorrectionEvaluator
+from helper.ff_evaluators import FakeFactorCorrectionEvaluator, FakeFactorEvaluator
 
 
 def calculation_Wjets_FFs(
@@ -47,7 +49,7 @@ def calculation_Wjets_FFs(
     corrlib_expressions = dict()
 
     # get QCD specific config information
-    process_conf = config["target_processes"]["Wjets"]
+    process_conf = defaultdict(lambda: None, config["target_processes"]["Wjets"])
 
     split_variables, split_combinations = func.get_split_combinations(
         categories=process_conf["split_categories"]
@@ -235,6 +237,7 @@ def calculation_Wjets_FFs(
             ff_hists=[FF_hist.Clone(), FF_hist_up, FF_hist_down],
             bin_edges=process_conf["var_bins"],
             logger=logger,
+            fit_option=process_conf["fit_option"],
         )
 
         plotting.plot_FFs(

--- a/FF_calculation/FF_Wjets.py
+++ b/FF_calculation/FF_Wjets.py
@@ -237,7 +237,7 @@ def calculation_Wjets_FFs(
             ff_hists=[FF_hist.Clone(), FF_hist_up, FF_hist_down],
             bin_edges=process_conf["var_bins"],
             logger=logger,
-            fit_option=process_conf["fit_option"],
+            fit_option=process_conf.get("fit_option", ("poly_1")),
         )
 
         plotting.plot_FFs(

--- a/FF_calculation/FF_ttbar.py
+++ b/FF_calculation/FF_ttbar.py
@@ -23,6 +23,7 @@ def calculation_ttbar_FFs(
     output_path: str,
     process: str,
     logger: str,
+    **kwargs: Dict[str, Any],
 ) -> Dict[str, Union[Dict[str, str], Dict[str, Dict[str, str]]]]:
     """
     This function calculates fake factors for ttbar.
@@ -289,7 +290,7 @@ def calculation_ttbar_FFs(
             ff_hists=FF_hist.Clone(),
             bin_edges=process_conf["var_bins"],
             logger=logger,
-            fit_option=process_conf.get("fit_option", ("poly_1")),
+            fit_option=process_conf.get("fit_option", "poly_1"),
         )
 
         plotting.plot_FFs(
@@ -302,6 +303,7 @@ def calculation_ttbar_FFs(
             category=split,
             output_path=output_path,
             logger=logger,
+            draw_option=process_conf.get("fit_option", "fit")
         )
 
         if len(split) == 1:

--- a/FF_calculation/FF_ttbar.py
+++ b/FF_calculation/FF_ttbar.py
@@ -5,7 +5,6 @@ Function for calculating fake factors for the ttbar process
 import array
 import copy
 import logging
-from collections import defaultdict
 from io import StringIO
 from typing import Any, Dict, List, Union
 
@@ -54,7 +53,7 @@ def calculation_ttbar_FFs(
     corrlib_expressions = dict()
 
     # get QCD specific config information
-    process_conf = defaultdict(lambda: None, config["target_processes"][process])
+    process_conf = config["target_processes"][process]
 
     split_variables, split_combinations = func.get_split_combinations(
         categories=process_conf["split_categories"]
@@ -290,7 +289,7 @@ def calculation_ttbar_FFs(
             ff_hists=FF_hist.Clone(),
             bin_edges=process_conf["var_bins"],
             logger=logger,
-            fit_option=process_conf["fit_option"],
+            fit_option=process_conf.get("fit_option", ("poly_1")),
         )
 
         plotting.plot_FFs(

--- a/FF_calculation/FF_ttbar.py
+++ b/FF_calculation/FF_ttbar.py
@@ -9,7 +9,7 @@ import numpy as np
 from io import StringIO
 from wurlitzer import pipes, STDOUT
 import logging
-from typing import Union, Dict, List
+from typing import Union, Dict, List, Any
 
 import helper.ff_functions as func
 import helper.plotting as plotting
@@ -425,6 +425,7 @@ def non_closure_correction(
     evaluator: FakeFactorEvaluator,
     corr_evaluator: FakeFactorCorrectionEvaluator,
     logger: str,
+    **kwargs: Dict[str, Any],
 ) -> Dict[str, np.ndarray]:
     """
     This function calculates non closure corrections for fake factors for ttbar.

--- a/FF_calculation/FF_ttbar.py
+++ b/FF_calculation/FF_ttbar.py
@@ -291,6 +291,7 @@ def calculation_ttbar_FFs(
             bin_edges=process_conf["var_bins"],
             logger=logger,
             fit_option=process_conf.get("fit_option", "poly_1"),
+            limit_and_replace_kwargs=process_conf.get("limit_and_replace_kwargs", {}),  # TODO: Build an config interface for that
         )
 
         plotting.plot_FFs(

--- a/FF_calculation/FF_ttbar.py
+++ b/FF_calculation/FF_ttbar.py
@@ -4,16 +4,18 @@ Function for calculating fake factors for the ttbar process
 
 import array
 import copy
-import ROOT
-import numpy as np
-from io import StringIO
-from wurlitzer import pipes, STDOUT
 import logging
-from typing import Union, Dict, List, Any
+from collections import defaultdict
+from io import StringIO
+from typing import Any, Dict, List, Union
+
+import numpy as np
+import ROOT
+from wurlitzer import STDOUT, pipes
 
 import helper.ff_functions as func
 import helper.plotting as plotting
-from helper.ff_evaluators import FakeFactorEvaluator, FakeFactorCorrectionEvaluator
+from helper.ff_evaluators import FakeFactorCorrectionEvaluator, FakeFactorEvaluator
 
 
 def calculation_ttbar_FFs(
@@ -52,7 +54,7 @@ def calculation_ttbar_FFs(
     corrlib_expressions = dict()
 
     # get QCD specific config information
-    process_conf = config["target_processes"][process]
+    process_conf = defaultdict(lambda: None, config["target_processes"][process])
 
     split_variables, split_combinations = func.get_split_combinations(
         categories=process_conf["split_categories"]
@@ -288,6 +290,7 @@ def calculation_ttbar_FFs(
             ff_hists=FF_hist.Clone(),
             bin_edges=process_conf["var_bins"],
             logger=logger,
+            fit_option=process_conf["fit_option"],
         )
 
         plotting.plot_FFs(

--- a/FF_calculation/fractions.py
+++ b/FF_calculation/fractions.py
@@ -8,7 +8,7 @@ import ROOT
 from io import StringIO
 from wurlitzer import pipes, STDOUT
 import logging
-from typing import Union, Dict, List
+from typing import Union, Dict, List, Any
 
 import helper.ff_functions as func
 import helper.plotting as plotting
@@ -20,6 +20,7 @@ def fraction_calculation(
     output_path: str,
     process: str,
     logger: str,
+    **kwargs: Dict[str, Any],
 ) -> Dict[str, Dict[str, Dict[str, List[float]]]]:
     """
     This function calculates fractions of processes for the application of fake factors.

--- a/FF_calculation/fractions.py
+++ b/FF_calculation/fractions.py
@@ -4,11 +4,12 @@ Function for calculating the process fractions for the fake factors
 
 import array
 import copy
-import ROOT
-from io import StringIO
-from wurlitzer import pipes, STDOUT
 import logging
-from typing import Union, Dict, List, Any
+from io import StringIO
+from typing import Any, Dict, List, Union
+
+import ROOT
+from wurlitzer import STDOUT, pipes
 
 import helper.ff_functions as func
 import helper.plotting as plotting

--- a/configs/general_definitions.py
+++ b/configs/general_definitions.py
@@ -15,9 +15,9 @@ output_features = {
         "tt": ["fj_Xbb_hadflavor", "fj_Xbb_nBhad", "fj_Xbb_nChad", "weight", "btag_weight", "pNet_Xbb_weight", "njets", "nbtag", "q_1", "pt_2", "q_2", "gen_match_1", "gen_match_2", "m_vis", "mt_1", "deltaR_ditaupair", "pt_1", "iso_1", "metphi", "extramuon_veto", "extraelec_veto", "fj_Xbb_pt", "fj_Xbb_eta", "fj_Xbb_particleNet_XbbvsQCD", "bpair_pt_1", "bpair_pt_2", "bpair_btag_value_2", "bpair_eta_2", "met", "mass_1", "tau_decaymode_1", "mass_2", "tau_decaymode_2"],
     },
     "smhtt_ul": {
-        "et": ["weight", "btag_weight", "njets", "nbtag", "q_1", "pt_2", "q_2", "gen_match_2", "m_vis", "mt_1", "deltaR_ditaupair", "pt_1", "iso_1", "metphi", "extramuon_veto", "extraelec_veto"],
-        "mt": ["weight", "btag_weight", "njets", "nbtag", "q_1", "pt_2", "q_2", "gen_match_2", "m_vis", "mt_1", "deltaR_ditaupair", "pt_1", "iso_1", "metphi", "extramuon_veto", "extraelec_veto", "dimuon_veto"],
-        "tt": ["weight", "btag_weight", "njets", "nbtag", "q_1", "pt_2", "q_2", "gen_match_1", "gen_match_2", "m_vis", "mt_1", "deltaR_ditaupair", "pt_1", "iso_1", "metphi", "extramuon_veto", "extraelec_veto"],
+        "et": ["weight", "btag_weight", "njets", "nbtag", "q_1", "pt_2", "q_2", "gen_match_2", "m_vis", "mt_1", "deltaR_ditaupair", "pt_1", "iso_1", "metphi", "extramuon_veto", "extraelec_veto", "tau_decaymode_2"],
+        "mt": ["weight", "btag_weight", "njets", "nbtag", "q_1", "pt_2", "q_2", "gen_match_2", "m_vis", "mt_1", "deltaR_ditaupair", "pt_1", "iso_1", "metphi", "extramuon_veto", "extraelec_veto", "dimuon_veto", "tau_decaymode_2"],
+        "tt": ["weight", "btag_weight", "njets", "nbtag", "q_1", "pt_2", "q_2", "gen_match_1", "gen_match_2", "m_vis", "mt_1", "deltaR_ditaupair", "pt_1", "iso_1", "metphi", "extramuon_veto", "extraelec_veto", "tau_decaymode_2", "tau_decaymode_1"],
     },
 }
 
@@ -106,6 +106,7 @@ variable_dict = {
         "njets": "number of jets",
         "nbtag": "number of b-tagged jets",
         "deltaR_ditaupair": "#DeltaR(e#tau_{h})",
+        "tau_decaymode_2": "#tau_{h}^{DM} ",
     },
     "mt": {
         "pt_1": "p_{T}(#mu) (GeV)",
@@ -123,6 +124,7 @@ variable_dict = {
         "njets": "number of jets",
         "nbtag": "number of b-tagged jets",
         "deltaR_ditaupair": "#DeltaR(#mu#tau_{h})",
+        "tau_decaymode_2": "#tau_{h}^{DM}",
     },
     "tt": {
         "pt_1": "leading p_{T}(#tau_{h}) (GeV)",
@@ -139,6 +141,8 @@ variable_dict = {
         "njets": "number of jets",
         "nbtag": "number of b-tagged jets",
         "deltaR_ditaupair": "#DeltaR(#tau_{h}#tau_{h})",
+        "tau_decaymode_1": "#tau_{h, 1}^{DM}",
+        "tau_decaymode_2": "#tau_{h, 2}^{DM}",
     },
 }
 # definitions to translate category cuts to readable language
@@ -147,6 +151,8 @@ category_dict = {
     "njets": "N_{jets}",
     "nbtag": "N_{b-jets}",
     "deltaR_ditaupair": "#Delta" + "R(l#tau_{h})",
+    "tau_decaymode_1": "#tau_{h, 1}^{DM}",
+    "tau_decaymode_2": "#tau_{h, 2}^{DM}",
 }
 
 ### For correctionlib ###
@@ -167,6 +173,8 @@ variable_translator = {
     "QCD": "QCD",
     "Wjets": "Wjets",
     "ttbar_J": "ttbar",
+    "tau_decaymode_1": "leading_tau_decaymode",
+    "tau_decaymode_2": "subleading_tau_decaymode",
 }
 # definitions for the variable type, needed for correctionlib
 variable_type = {
@@ -181,6 +189,8 @@ variable_type = {
     "njets": "real",
     "nbtag": "real",
     "deltaR_ditaupair": "real",
+    "tau_decaymode_1": "int",
+    "tau_decaymode_2": "int",
 }
 # definitions for variable descriptions, needed for correctionlib, #var_max and #var_min are replaced later by using the variable binning
 variable_description = {
@@ -195,6 +205,8 @@ variable_description = {
     "njets": "number of jets in an event; the defined categories are ",
     "nbtag": "number of b-tagged jets in an event; the defined categories are ",
     "deltaR_ditaupair": "spatial distance between the tau pair with deltaR ",
+    "tau_decaymode_1": "decay mode of the leading tau in the tau pair; the defined categories are ",
+    "tau_decaymode_2": "decay mode of the subleading tau in the tau pair; the defined categories are ",
 }
 # intern naming translation helper for fit uncertainties
 # naming has to match the one used in helper/ff_functions.py -> fit_function()

--- a/configs/general_definitions.py
+++ b/configs/general_definitions.py
@@ -60,7 +60,7 @@ color_dict = {
     "tau_fakes": (185, 172, 112),
     "data_ff": (255, 169, 14),
     "fit_graph_mc_sub": ROOT.kGreen,
-    "fit_graph_unct": ROOT.kRed,
+    "fit_graph_unc": ROOT.kRed,
 }
 # definitions for process labels on the plots
 label_dict = {
@@ -83,8 +83,14 @@ label_dict = {
     "data_subtracted": "reduced Data",
     "data_ff": "Data with FFs",
     "tau_fakes": "jet#rightarrow#tau_{h}",
-    "fit_graph_unct": "best fit uncertainty",
-    "fit_graph_mc_sub": "best fit (MC subtraction unc.)",
+    "fit_graph_unc": {
+        "fit": "best fit uncertainty",
+        "hist": "FF",
+    },
+    "fit_graph_mc_sub": {
+        "fit": "best fit (MC subtraction unc.)",
+        "hist": "FF (MC subtraction unc.)",
+    },
 }
 # definitions to translate variable to readable language, channel dependent
 variable_dict = {

--- a/configs/general_definitions.py
+++ b/configs/general_definitions.py
@@ -59,9 +59,8 @@ color_dict = {
     "embedding": (255, 169, 14),
     "tau_fakes": (185, 172, 112),
     "data_ff": (255, 169, 14),
-    "fit_graph_slope": ROOT.kBlue,
-    "fit_graph_norm": ROOT.kRed,
     "fit_graph_mc_sub": ROOT.kGreen,
+    "fit_graph_unct": ROOT.kRed,
 }
 # definitions for process labels on the plots
 label_dict = {
@@ -84,8 +83,7 @@ label_dict = {
     "data_subtracted": "reduced Data",
     "data_ff": "Data with FFs",
     "tau_fakes": "jet#rightarrow#tau_{h}",
-    "fit_graph_slope": "best fit (slope unc.)",
-    "fit_graph_norm": "best fit (normalization unc.)",
+    "fit_graph_unct": "best fit uncertainty",
     "fit_graph_mc_sub": "best fit (MC subtraction unc.)",
 }
 # definitions to translate variable to readable language, channel dependent
@@ -131,8 +129,8 @@ variable_dict = {
         "eta_1": "leading #eta(#tau_{h})",
         "phi_1": "leading #phi(#tau_{h})",
         "pt_2": "subleading p_{T}(#tau_{h}) (GeV)",
-        "eta_1": "subleading #eta(#tau_{h})",
-        "phi_1": "subleading #phi(#tau_{h})",
+        "eta_2": "subleading #eta(#tau_{h})",
+        "phi_2": "subleading #phi(#tau_{h})",
         "mass_1": "leading #tau_{h} mass",
         "mass_2": "subleading #tau_{h} mass",
         "m_vis": "m_{vis} (GeV)",
@@ -189,8 +187,8 @@ variable_type = {
     "njets": "real",
     "nbtag": "real",
     "deltaR_ditaupair": "real",
-    "tau_decaymode_1": "int",
-    "tau_decaymode_2": "int",
+    "tau_decaymode_1": "real",
+    "tau_decaymode_2": "real",
 }
 # definitions for variable descriptions, needed for correctionlib, #var_max and #var_min are replaced later by using the variable binning
 variable_description = {
@@ -211,41 +209,21 @@ variable_description = {
 # intern naming translation helper for fit uncertainties
 # naming has to match the one used in helper/ff_functions.py -> fit_function()
 ff_variation_dict = {
-    "QCD": {
-        "slope_unc_up": "FFslopeUncUp",
-        "slope_unc_down": "FFslopeUncDown",
-        "normalization_unc_up": "FFnormUncUp",
-        "normalization_unc_down": "FFnormUncDown",
-        "mc_subtraction_unc_up": "FFmcSubUncUp",
-        "mc_subtraction_unc_down": "FFmcSubUncDown",
+    **{
+        k: {
+            "unc_up": "FFuncUp",
+            "unc_down": "FFuncDown",
+            "mc_subtraction_unc_up": "FFmcSubUncUp",
+            "mc_subtraction_unc_down": "FFmcSubUncDown",
+        }
+        for k in ["QCD", "QCD_subleading", "Wjets"]
     },
-    "QCD_subleading": {
-        "slope_unc_up": "FFslopeUncUp",
-        "slope_unc_down": "FFslopeUncDown",
-        "normalization_unc_up": "FFnormUncUp",
-        "normalization_unc_down": "FFnormUncDown",
-        "mc_subtraction_unc_up": "FFmcSubUncUp",
-        "mc_subtraction_unc_down": "FFmcSubUncDown",
-    },
-    "Wjets": {
-        "slope_unc_up": "FFslopeUncUp",
-        "slope_unc_down": "FFslopeUncDown",
-        "normalization_unc_up": "FFnormUncUp",
-        "normalization_unc_down": "FFnormUncDown",
-        "mc_subtraction_unc_up": "FFmcSubUncUp",
-        "mc_subtraction_unc_down": "FFmcSubUncDown",
-    },
-    "ttbar": {
-        "slope_unc_up": "FFslopeUncUp",
-        "slope_unc_down": "FFslopeUncDown",
-        "normalization_unc_up": "FFnormUncUp",
-        "normalization_unc_down": "FFnormUncDown",
-    },
-    "ttbar_subleading": {
-        "slope_unc_up": "FFslopeUncUp",
-        "slope_unc_down": "FFslopeUncDown",
-        "normalization_unc_up": "FFnormUncUp",
-        "normalization_unc_down": "FFnormUncDown",
+    **{
+        k: {
+            "unc_up": "FFuncUp",
+            "unc_down": "FFuncDown",
+        }
+        for k in ["ttbar", "ttbar_subleading"]
     },
 }
 # intern naming translation helper for fraction uncertainties

--- a/configs/smhtt_ul/2018/common_settings.yaml
+++ b/configs/smhtt_ul/2018/common_settings.yaml
@@ -1,10 +1,10 @@
-ntuple_path: "root://cmsdcache-kit-disk.gridka.de//store/user/amonsch/CROWN/ntuples/ff_production_2018UL_mt_et_tt__2024-11-21_v1/CROWNRun"
-output_path: /ceph/amonsch/FFmethod/smhtt_ul/ff_production_2018UL_mt_et_tt__2024-11-21_v1
+ntuple_path: "root://cmsdcache-kit-disk.gridka.de//store/user/amonsch/CROWN/ntuples/ff_and_cr_production_2018UL_mt_et_tt__2024-12-31_wo_filterbits_v1/CROWNRun"
+output_path: /ceph/amonsch/FFmethod/smhtt_ul/ff_and_cr_production_2018UL_mt_et_tt__2024-12-31_wo_filterbits_v1
 
-file_paths: /ceph/amonsch/FFmethod/smhtt_ul/ff_production_2018UL_mt_et_tt__2024-11-21_v1
-file_path: /ceph/amonsch/FFmethod/smhtt_ul/ff_production_2018UL_mt_et_tt__2024-11-21_v1
+file_paths: /ceph/amonsch/FFmethod/smhtt_ul/ff_and_cr_production_2018UL_mt_et_tt__2024-12-31_wo_filterbits_v1
+file_path: /ceph/amonsch/FFmethod/smhtt_ul/ff_and_cr_production_2018UL_mt_et_tt__2024-12-31_wo_filterbits_v1
 
-workdir_name: ff_production_2018UL_mt_et_tt__2024-11-21_v1
+workdir_name: ff_and_cr_production_2018UL_mt_et_tt__2024-12-31_wo_filterbits_v1_delmetests
 
 era: '2018'
 tree: ntuple

--- a/configs/smhtt_ul/2018/common_settings.yaml
+++ b/configs/smhtt_ul/2018/common_settings.yaml
@@ -1,5 +1,7 @@
-workdir_name: "full_set_v13"
-file_path: "/ceph/sbrommer/FFmethod/smhtt_ul/03_2023_v5"
-output_path: "/ceph/sbrommer/FFmethod/smhtt_ul/03_2023_v5"
-ntuple_path: "root://cmsxrootd-kit.gridka.de//store/user/sbrommer/CROWN/ntuples/2018_ul_v4/CROWNRun"
-era: "2018"
+ntuple_path: root://cmsdcache-kit-disk.gridka.de//store/user/amonsch/CROWN/ntuples/ff_production_2018UL_mt_et_tt__2024-09-27__v1/CROWNRun
+output_path: /ceph/amonsch/FFmethod/smhtt_ul/ff_production_2018UL_mt_et_tt__2024-09-27__v1
+file_paths: /ceph/amonsch/FFmethod/smhtt_ul/ff_production_2018UL_mt_et_tt__2024-09-27__v1
+file_path: /ceph/amonsch/FFmethod/smhtt_ul/ff_production_2018UL_mt_et_tt__2024-09-27__v1
+workdir_name: ff_production_2018UL_mt_et_tt__2024-09-27__v1
+era: '2018'
+

--- a/configs/smhtt_ul/2018/common_settings.yaml
+++ b/configs/smhtt_ul/2018/common_settings.yaml
@@ -1,7 +1,14 @@
-ntuple_path: root://cmsdcache-kit-disk.gridka.de//store/user/amonsch/CROWN/ntuples/ff_production_2018UL_mt_et_tt__2024-09-27__v1/CROWNRun
-output_path: /ceph/amonsch/FFmethod/smhtt_ul/ff_production_2018UL_mt_et_tt__2024-09-27__v1
-file_paths: /ceph/amonsch/FFmethod/smhtt_ul/ff_production_2018UL_mt_et_tt__2024-09-27__v1
-file_path: /ceph/amonsch/FFmethod/smhtt_ul/ff_production_2018UL_mt_et_tt__2024-09-27__v1
-workdir_name: ff_production_2018UL_mt_et_tt__2024-09-27__v1
+ntuple_path: "root://cmsdcache-kit-disk.gridka.de//store/user/amonsch/CROWN/ntuples/ff_production_2018UL_mt_et_tt__2024-11-21_v1/CROWNRun"
+output_path: /ceph/amonsch/FFmethod/smhtt_ul/ff_production_2018UL_mt_et_tt__2024-11-21_v1
+
+file_paths: /ceph/amonsch/FFmethod/smhtt_ul/ff_production_2018UL_mt_et_tt__2024-11-21_v1
+file_path: /ceph/amonsch/FFmethod/smhtt_ul/ff_production_2018UL_mt_et_tt__2024-11-21_v1
+
+workdir_name: ff_production_2018UL_mt_et_tt__2024-11-21_v1
+
 era: '2018'
+tree: ntuple
+analysis: smhtt_ul
+
+use_embedding: true
 

--- a/configs/smhtt_ul/2018/corrections_et.yaml
+++ b/configs/smhtt_ul/2018/corrections_et.yaml
@@ -4,11 +4,11 @@ target_processes:
     non_closure:
       leading_lep_pt:
         var_dependence: pt_1
-        var_bins: [25, 30, 40, 50, 60, 70, 80, 90, 100, 120]
+        var_bins: [0, 25, 30, 40, 50, 60, 70, 80, 90, 100, 120]
 
       lep_iso:
         var_dependence: iso_1
-        var_bins: [0.0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.31]
+        var_bins: [0., 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.15, 0.2, 0.25, 0.31]
         SRlike_cuts:
           lep_iso: iso_1 >= 0.0
         ARlike_cuts:
@@ -37,7 +37,7 @@ target_processes:
         var_bins: [25, 30, 40, 50, 60, 70, 80, 90, 100, 120]
       lep_iso:
         var_dependence: "iso_1"
-        var_bins: [0., 0.01, 0.05, 0.1, 0.15, 0.2, 0.25, 0.31]
+        var_bins: [0., 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.15, 0.2, 0.25, 0.31]
         SRlike_cuts:
             lep_iso: "iso_1 >= 0.0"
         ARlike_cuts:

--- a/configs/smhtt_ul/2018/corrections_et.yaml
+++ b/configs/smhtt_ul/2018/corrections_et.yaml
@@ -1,58 +1,67 @@
-# This is an example config containing information for the FF corrections
-
-workdir_name: "full_set_v13"
-era: "2018"
-channel: "et" # options are et, mt, tt
-
+channel: et
 target_processes:
-    QCD:
-        non_closure:
-            leading_lep_pt:
-                var_dependence: "pt_1"
-                var_bins: [25,30,40,50,60,70,80,90,100,120]
-            lep_iso:
-                var_dependence: "iso_1"
-                var_bins: [0.00,0.05,0.1,0.15,0.2,0.25,0.31]
-                SRlike_cuts:
-                    lep_iso: "iso_1 >= 0.0"
-                ARlike_cuts:
-                    lep_iso: "iso_1 >= 0.0"
-        DR_SR:
-            var_dependence: "m_vis"
-            var_bins: [0,40,60,80,100,120,140,160,180,250]
-            SRlike_cuts:
-                lep_iso: "iso_1 >= 0.15"
-            ARlike_cuts:
-                lep_iso: "iso_1 >= 0.15"
-            AR_SR_cuts:
-                tau_pair_sign: "(q_1*q_2) < 0"
-            non_closure:
-                leading_lep_pt:
-                    var_dependence: "pt_1"
-                    var_bins: [25,30,40,50,60,70,80,90,100,120]
+  QCD:
+    non_closure:
+      leading_lep_pt:
+        var_dependence: pt_1
+        var_bins: [25, 30, 40, 50, 60, 70, 80, 90, 100, 120]
 
-    Wjets:
-        non_closure:
-            leading_lep_pt:
-                var_dependence: "pt_1"
-                var_bins: [25,30,40,50,60,70,80,90,100,120]
-        DR_SR:
-            var_dependence: "m_vis"
-            var_bins: [0,40,70,100,140,180,250]
-            SRlike_cuts:
-                lep_mt: "mt_1 >= 0.0"
-            ARlike_cuts:
-                lep_mt: "mt_1 >= 0.0"
-            AR_SR_cuts:
-                njets: "nbtag >= 1"
-            non_closure:
-                leading_lep_pt:
-                    var_dependence: "pt_1"
-                    var_bins: [25,30,40,50,60,70,80,90,100,120]
+      lep_iso:
+        var_dependence: iso_1
+        var_bins: [0.0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.31]
+        SRlike_cuts:
+          lep_iso: iso_1 >= 0.0
+        ARlike_cuts:
+          lep_iso: iso_1 >= 0.0
 
-    ttbar:
-        non_closure:
-            leading_lep_pt:
-                var_dependence: "pt_1"
-                var_bins: [25,30,40,50,60,70,80,90,100,120]
+    DR_SR:
+      var_dependence: m_vis
+      var_bins: [0, 40, 60, 80, 100, 120, 140, 160, 180, 250]
 
+      SRlike_cuts:
+        lep_iso: iso_1 >= 0.15
+      ARlike_cuts:
+        lep_iso: iso_1 >= 0.15
+      AR_SR_cuts:
+        tau_pair_sign: (q_1*q_2) < 0
+
+      non_closure:
+        leading_lep_pt:
+          var_dependence: pt_1
+          var_bins: [25, 30, 40, 50, 60, 70, 80, 90, 100, 120]
+
+  Wjets:
+    non_closure:
+      leading_lep_pt:
+        var_dependence: pt_1
+        var_bins: [25, 30, 40, 50, 60, 70, 80, 90, 100, 120]
+      lep_iso:
+        var_dependence: "iso_1"
+        var_bins: [0., 0.01, 0.05, 0.1, 0.15, 0.2, 0.25, 0.31]
+        SRlike_cuts:
+            lep_iso: "iso_1 >= 0.0"
+        ARlike_cuts:
+            lep_iso: "iso_1 >= 0.0"
+
+    DR_SR:
+      var_dependence: m_vis
+      var_bins: [0, 40, 70, 100, 140, 180, 250]
+
+      SRlike_cuts:
+        lep_mt: mt_1 >= 0.0
+      ARlike_cuts:
+        lep_mt: mt_1 >= 0.0
+      AR_SR_cuts:
+        nbtag: nbtag >= 0
+        lep_mt: mt_1 < 70
+
+      non_closure:
+        leading_lep_pt:
+          var_dependence: pt_1
+          var_bins: [25, 30, 40, 50, 60, 70, 80, 90, 100, 120]
+
+  ttbar:
+    non_closure:
+      leading_lep_pt:
+        var_dependence: pt_1
+        var_bins: [30, 40, 50, 60, 70, 80, 90, 100, 120]

--- a/configs/smhtt_ul/2018/corrections_mt.yaml
+++ b/configs/smhtt_ul/2018/corrections_mt.yaml
@@ -1,57 +1,65 @@
-# This is an example config containing information for the FF corrections
-
-workdir_name: "full_set_v13"
-era: "2018"
-channel: "mt" # options are et, mt, tt
-
+channel: mt
 target_processes:
-    QCD:
-        non_closure:
-            leading_lep_pt:
-                var_dependence: "pt_1"
-                var_bins: [25,30,40,50,60,70,80,90,100,120]
-            lep_iso:
-                var_dependence: "iso_1"
-                var_bins: [0.00,0.05,0.1,0.15,0.2,0.25,0.31]
-                SRlike_cuts:
-                    lep_iso: "iso_1 >= 0."
-                ARlike_cuts:
-                    lep_iso: "iso_1 >= 0."
-        DR_SR:
-            var_dependence: "m_vis"
-            var_bins: [0,40,60,80,100,120,140,160,180,250]
-            SRlike_cuts:
-                lep_iso: "iso_1 >= 0.15"
-            ARlike_cuts:
-                lep_iso: "iso_1 >= 0.15"
-            AR_SR_cuts:
-                tau_pair_sign: "(q_1*q_2) < 0"
-            non_closure:
-                leading_lep_pt:
-                    var_dependence: "pt_1"
-                    var_bins: [25,30,40,50,60,70,80,90,100,120]
+  QCD:
+    non_closure:
+      leading_lep_pt:
+        var_dependence: pt_1
+        var_bins: [25, 30, 40, 50, 60, 70, 80, 90, 100, 120]
 
-    Wjets:
-        non_closure:
-            leading_lep_pt:
-                var_dependence: "pt_1"
-                var_bins: [25,30,40,50,60,70,80,90,100,120]
-        DR_SR:
-            var_dependence: "m_vis"
-            var_bins: [0,40,70,100,140,180,250]
-            SRlike_cuts:
-                lep_mt: "mt_1 >= 0.0"
-            ARlike_cuts:
-                lep_mt: "mt_1 >= 0.0"
-            AR_SR_cuts:
-                njets: "nbtag >= 1"
-            non_closure:
-                leading_lep_pt:
-                    var_dependence: "pt_1"
-                    var_bins: [25,30,40,50,60,70,80,90,100,120]
+      lep_iso:
+        SRlike_cuts:
+          lep_iso: iso_1 >= 0.
+        ARlike_cuts:
+          lep_iso: iso_1 >= 0.
+        var_dependence: iso_1
+        var_bins: [0.0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.31]
 
-    ttbar:
-        non_closure:
-            leading_lep_pt:
-                var_dependence: "pt_1"
-                var_bins: [25,30,40,50,60,70,80,90,100,120]
+    DR_SR:
+      var_dependence: m_vis
+      var_bins: [0, 40, 60, 80, 100, 120, 140, 160, 180, 250]
+
+      SRlike_cuts:
+        lep_iso: iso_1 >= 0.15
+      ARlike_cuts:
+        lep_iso: iso_1 >= 0.15
+      AR_SR_cuts:
+        tau_pair_sign: (q_1*q_2) < 0
+
+      non_closure:
+        leading_lep_pt:
+          var_dependence: pt_1
+          var_bins: [25, 30, 40, 50, 60, 70, 80, 90, 100, 120]
+  Wjets:
+    non_closure:
+      leading_lep_pt:
+        var_dependence: pt_1
+        var_bins: [25, 30, 40, 50, 60, 70, 80, 90, 100, 120]
+      lep_iso:
+        var_dependence: "iso_1"
+        var_bins: [0., 0.01, 0.05, 0.1, 0.15, 0.2, 0.25, 0.31]
+        SRlike_cuts:
+            lep_iso: "iso_1 >= 0.0"
+        ARlike_cuts:
+            lep_iso: "iso_1 >= 0.0"
+
+    DR_SR:
+      var_dependence: m_vis
+      var_bins: [0, 40, 70, 100, 140, 180, 250]
+
+      SRlike_cuts:
+        lep_mt: mt_1 >= 0.0
+      ARlike_cuts:
+        lep_mt: mt_1 >= 0.0
+      AR_SR_cuts:
+        nbtag: nbtag >= 0
+        lep_mt: mt_1 < 70
+
+      non_closure:
+        leading_lep_pt:
+          var_dependence: pt_1
+          var_bins: [25, 30, 40, 50, 60, 70, 80, 90, 100, 120]
+  ttbar:
+    non_closure:
+      leading_lep_pt:
+        var_dependence: pt_1
+        var_bins: [25, 30, 40, 50, 60, 70, 80, 90, 100, 120]

--- a/configs/smhtt_ul/2018/corrections_mt.yaml
+++ b/configs/smhtt_ul/2018/corrections_mt.yaml
@@ -12,7 +12,7 @@ target_processes:
         ARlike_cuts:
           lep_iso: iso_1 >= 0.
         var_dependence: iso_1
-        var_bins: [0.0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.31]
+        var_bins: [0., 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.15, 0.2, 0.25, 0.31]
 
     DR_SR:
       var_dependence: m_vis
@@ -36,7 +36,7 @@ target_processes:
         var_bins: [25, 30, 40, 50, 60, 70, 80, 90, 100, 120]
       lep_iso:
         var_dependence: "iso_1"
-        var_bins: [0., 0.01, 0.05, 0.1, 0.15, 0.2, 0.25, 0.31]
+        var_bins: [0., 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.15, 0.2, 0.25, 0.31]
         SRlike_cuts:
             lep_iso: "iso_1 >= 0.0"
         ARlike_cuts:

--- a/configs/smhtt_ul/2018/corrections_tt.yaml
+++ b/configs/smhtt_ul/2018/corrections_tt.yaml
@@ -4,18 +4,18 @@ target_processes:
     non_closure:
       subleading_lep_pt:
         var_dependence: pt_2
-        var_bins: [30, 35, 40, 45, 50, 55, 60, 70, 80, 100]
-      m_vis:
-        var_dependence: "m_vis"
-        var_bins: [0, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 200, 250]
+        var_bins: [40, 45, 50, 55, 60, 70, 80, 100]
+      # m_vis:
+      #   var_dependence: "m_vis"
+      #   var_bins: [0, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 200, 250]
 
     DR_SR:
       var_dependence: m_vis
-      var_bins: [0, 30, 80, 90, 100, 120, 140, 160, 180, 250]
+      var_bins: [30, 80, 90, 100, 120, 140, 160, 180, 250]
       SRlike_cuts:
-        had_tau_id_vs_jet_2: (id_tau_vsJet_VVLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
+        had_tau_id_vs_jet_2: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
       ARlike_cuts:
-        had_tau_id_vs_jet_2: (id_tau_vsJet_VVLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
+        had_tau_id_vs_jet_2: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
       AR_SR_cuts:
         tau_pair_sign: (q_1*q_2) < 0
 
@@ -28,19 +28,19 @@ target_processes:
     non_closure:
       leading_lep_pt:
         var_dependence: pt_1
-        var_bins: [30, 35, 40, 45, 50, 55, 60, 70, 80, 100]
-      m_vis:
-        var_dependence: "m_vis"
-        var_bins: [0, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 200, 250]
+        var_bins: [40, 45, 50, 55, 60, 70, 80, 100]
+      # m_vis:
+      #   var_dependence: "m_vis"
+      #   var_bins: [0, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 200, 250]
 
     DR_SR:
       var_dependence: m_vis
-      var_bins: [0, 30, 80, 90, 100, 120, 140, 160, 180, 250]
+      var_bins: [30, 80, 90, 100, 120, 140, 160, 180, 250]
 
       SRlike_cuts:
-        had_tau_id_vs_jet_1: (id_tau_vsJet_VVLoose_1 > 0.5) && (id_tau_vsJet_Tight_1 < 0.5)
+        had_tau_id_vs_jet_1: (id_tau_vsJet_VLoose_1 > 0.5) && (id_tau_vsJet_Tight_1 < 0.5)
       ARlike_cuts:
-        had_tau_id_vs_jet_1: (id_tau_vsJet_VVLoose_1 > 0.5) && (id_tau_vsJet_Tight_1 < 0.5)
+        had_tau_id_vs_jet_1: (id_tau_vsJet_VLoose_1 > 0.5) && (id_tau_vsJet_Tight_1 < 0.5)
       AR_SR_cuts:
         tau_pair_sign: (q_1*q_2) < 0
 

--- a/configs/smhtt_ul/2018/corrections_tt.yaml
+++ b/configs/smhtt_ul/2018/corrections_tt.yaml
@@ -1,44 +1,50 @@
-# This is an example config containing information for the FF corrections
-
-workdir_name: "full_set_v1"
-era: "2018"
-channel: "tt" # options are et, mt, tt
-
+channel: tt
 target_processes:
-    QCD:
-        non_closure:
-            subleading_lep_pt:
-                var_dependence: "pt_2"
-                var_bins: [30,35,40,45,50,55,60,70,80,100]
-        DR_SR:
-            var_dependence: "m_vis"
-            var_bins: [0,30,80,90,100,120,140,160,180,250]
-            SRlike_cuts:
-                had_tau_id_vs_jet_2: "(id_tau_vsJet_VVLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)"
-            ARlike_cuts:
-                had_tau_id_vs_jet_2: "(id_tau_vsJet_VVLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)"
-            AR_SR_cuts:
-                tau_pair_sign: "(q_1*q_2) < 0"
-            non_closure:
-                subleading_lep_pt:
-                    var_dependence: "pt_2"
-                    var_bins: [40,45,50,55,60,65,70,75,80,85,90,95,100,110,120]
+  QCD:
+    non_closure:
+      subleading_lep_pt:
+        var_dependence: pt_2
+        var_bins: [30, 35, 40, 45, 50, 55, 60, 70, 80, 100]
+      m_vis:
+        var_dependence: "m_vis"
+        var_bins: [0, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 200, 250]
 
-    QCD_subleading:
-        non_closure:
-            leading_lep_pt:
-                var_dependence: "pt_1"
-                var_bins: [30,35,40,45,50,55,60,70,80,100]
-        DR_SR:
-            var_dependence: "m_vis"
-            var_bins: [0,30,80,90,100,120,140,160,180,250]
-            SRlike_cuts:
-                had_tau_id_vs_jet_2: "(id_tau_vsJet_VVLoose_1 > 0.5) && (id_tau_vsJet_Tight_1 < 0.5)"
-            ARlike_cuts:
-                had_tau_id_vs_jet_2: "(id_tau_vsJet_VVLoose_1 > 0.5) && (id_tau_vsJet_Tight_1 < 0.5)"
-            AR_SR_cuts:
-                tau_pair_sign: "(q_1*q_2) < 0"
-            non_closure:
-                subleading_lep_pt:
-                    var_dependence: "pt_1"
-                    var_bins: [40,45,50,55,60,65,70,75,80,85,90,95,100,110,120]
+    DR_SR:
+      var_dependence: m_vis
+      var_bins: [0, 30, 80, 90, 100, 120, 140, 160, 180, 250]
+      SRlike_cuts:
+        had_tau_id_vs_jet_2: (id_tau_vsJet_VVLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
+      ARlike_cuts:
+        had_tau_id_vs_jet_2: (id_tau_vsJet_VVLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
+      AR_SR_cuts:
+        tau_pair_sign: (q_1*q_2) < 0
+
+      non_closure:
+        subleading_lep_pt:
+          var_dependence: pt_2
+          var_bins: [40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 110, 120]
+
+  QCD_subleading:
+    non_closure:
+      leading_lep_pt:
+        var_dependence: pt_1
+        var_bins: [30, 35, 40, 45, 50, 55, 60, 70, 80, 100]
+      m_vis:
+        var_dependence: "m_vis"
+        var_bins: [0, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 200, 250]
+
+    DR_SR:
+      var_dependence: m_vis
+      var_bins: [0, 30, 80, 90, 100, 120, 140, 160, 180, 250]
+
+      SRlike_cuts:
+        had_tau_id_vs_jet_1: (id_tau_vsJet_VVLoose_1 > 0.5) && (id_tau_vsJet_Tight_1 < 0.5)
+      ARlike_cuts:
+        had_tau_id_vs_jet_1: (id_tau_vsJet_VVLoose_1 > 0.5) && (id_tau_vsJet_Tight_1 < 0.5)
+      AR_SR_cuts:
+        tau_pair_sign: (q_1*q_2) < 0
+
+      non_closure:
+        leading_lep_pt:
+          var_dependence: pt_1
+          var_bins: [40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 110, 120]

--- a/configs/smhtt_ul/2018/fake_factors_et.yaml
+++ b/configs/smhtt_ul/2018/fake_factors_et.yaml
@@ -1,6 +1,4 @@
 channel: et
-tree: ntuple
-use_embedding: true
 target_processes:
   QCD:
     split_categories:

--- a/configs/smhtt_ul/2018/fake_factors_et.yaml
+++ b/configs/smhtt_ul/2018/fake_factors_et.yaml
@@ -7,92 +7,117 @@ target_processes:
         - "==1"
         - ">=2"
     split_categories_binedges:
-      njets: [-0.5, 0.5, 1.5, 2.5]
+      njets: [-0.5, 0.5, 1.5, 12.5]
 
     SRlike_cuts:
-      tau_pair_sign: (q_1*q_2) > 0
-      lep_mt: mt_1 < 50
-      lep_iso: (iso_1 > 0.05) && (iso_1 < 0.15)
-      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
       had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
+      # -------------------------------------------
+      lep_mt: (mt_1 < 50)
+      nbtag: (nbtag >= 0)
+      tau_pair_sign: ((q_1*q_2) > 0)
+      lep_iso: ((iso_1 > 0.02) && (iso_1 < 0.15))
+      # -------------------------------------------
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
 
     ARlike_cuts:
-      tau_pair_sign: (q_1*q_2) > 0
-      lep_mt: mt_1 < 50
-      lep_iso: (iso_1 > 0.05) && (iso_1 < 0.15)
-      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
       had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
+      # -------------------------------------------
+      lep_mt: (mt_1 < 50)
+      nbtag: (nbtag >= 0)
+      tau_pair_sign: ((q_1*q_2) > 0)
+      lep_iso: ((iso_1 > 0.02) && (iso_1 < 0.15))
+      # -------------------------------------------
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
 
     var_dependence: pt_2
-    var_bins: [30, 32, 35, 40, 48, 70, 100]
+    var_bins: [30, 35, 40, 50, 60, 75, 90, 115]
+    ff_type: "poly1"
 
   Wjets:
     split_categories:
-      deltaR_ditaupair:
-        - "<3"
-        - ">=3"
       njets:
         - "==0"
         - "==1"
         - ">=2"
+      deltaR_ditaupair:
+        - "<3"
+        - ">=3"
     split_categories_binedges:
+      njets: [-0.5, 0.5, 1.5, 12.5]
       deltaR_ditaupair: [0.0, 3.0, 10.0]
-      njets: [-0.5, 0.5, 1.5, 2.5]
 
     SRlike_cuts:
-      tau_pair_sign: (q_1*q_2) < 0
-      lep_mt: mt_1 > 70
-      lep_iso: iso_1 < 0.15
-      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
       had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
-      nbtag: nbtag == 0
-    ARlike_cuts:
-      tau_pair_sign: (q_1*q_2) < 0
-      lep_mt: mt_1 > 70
-      lep_iso: iso_1 < 0.15
+      # -------------------------------------------
+      lep_mt: (mt_1 >= 70)
+      nbtag: (nbtag == 0)
+      tau_pair_sign: ((q_1*q_2) < 0)
+      lep_iso: ((iso_1 > 0.0) && (iso_1 < 0.15))
+      # -------------------------------------------
       no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
+    ARlike_cuts:
       had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
-      nbtag: nbtag == 0
+      # -------------------------------------------
+      lep_mt: (mt_1 >= 70)
+      nbtag: (nbtag == 0)
+      tau_pair_sign: ((q_1*q_2) < 0)
+      lep_iso: ((iso_1 > 0.0) && (iso_1 < 0.15))
+      # -------------------------------------------
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
 
     var_dependence: pt_2
-    var_bins: [30, 32, 38, 47, 60, 100]
+    var_bins: [30, 35, 40, 50, 60, 75, 90, 115]
 
   ttbar:
     split_categories:
       njets:
-        - "<=1"
+        - "<2"
         - ">=2"
     split_categories_binedges:
-      njets: [-0.5, 1.5, 2.5]
+      njets: [-0.5, 1.5, 12.5]
 
     SR_cuts:
-      tau_pair_sign: (q_1*q_2) < 0
-      lep_iso: iso_1 < 0.15
-      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
       had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
-      nbtag: nbtag >= 1
-    AR_cuts:
-      tau_pair_sign: (q_1*q_2) < 0
-      lep_iso: iso_1 < 0.15
+      # -------------------------------------------
+      lep_mt: (mt_1 < 70)
+      nbtag: (nbtag >= 0)
+      tau_pair_sign: ((q_1*q_2) < 0)
+      lep_iso: ((iso_1 > 0.0) && (iso_1 < 0.15))
+      # -------------------------------------------
       no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
+
+    AR_cuts:
       had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
-      nbtag: nbtag >= 1
+      # -------------------------------------------
+      lep_mt: (mt_1 < 70)
+      nbtag: (nbtag >= 0)
+      tau_pair_sign: ((q_1*q_2) < 0)
+      lep_iso: ((iso_1 > 0.0) && (iso_1 < 0.15))
+      # -------------------------------------------
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
 
     SRlike_cuts:
-      tau_pair_sign: (q_1*q_2) < 0
-      lep_iso: iso_1 < 0.15
-      no_extra_lep: "!((extramuon_veto < 0.5) && (extraelec_veto < 0.5))"
       had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
-      nbtag: nbtag >= 1
-    ARlike_cuts:
-      tau_pair_sign: (q_1*q_2) < 0
-      lep_iso: iso_1 < 0.15
+      # -------------------------------------------
+      lep_mt: (mt_1 < 70)
+      nbtag: (nbtag >= 0)
+      tau_pair_sign: ((q_1*q_2) < 0)
+      lep_iso: ((iso_1 > 0.0) && (iso_1 < 0.15))
+      # -------------------------------------------
       no_extra_lep: "!((extramuon_veto < 0.5) && (extraelec_veto < 0.5))"
+
+    ARlike_cuts:
       had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
-      nbtag: nbtag >= 1
+      # -------------------------------------------
+      lep_mt: (mt_1 < 70)
+      nbtag: (nbtag >= 0)
+      tau_pair_sign: ((q_1*q_2) < 0)
+      lep_iso: ((iso_1 > 0.0) && (iso_1 < 0.15))
+      # -------------------------------------------
+      no_extra_lep: "!((extramuon_veto < 0.5) && (extraelec_veto < 0.5))"
 
     var_dependence: pt_2
-    var_bins: [30, 32, 35, 38, 41, 44, 52, 70, 100]
+    var_bins: [30, 35, 40, 50, 60, 75, 90, 115]
 
 process_fractions:
   processes: ["QCD", "Wjets", "ttbar_J"]
@@ -103,18 +128,26 @@ process_fractions:
       - "==1"
       - ">=2"
   split_categories_binedges:
-    njets: [-0.5, 0.5, 1.5, 2.5]
+    njets: [-0.5, 0.5, 1.5, 12.5]
 
   SR_cuts:
-    tau_pair_sign: (q_1*q_2) < 0
-    lep_iso: iso_1 < 0.15
-    no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
     had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
-  AR_cuts:
-    tau_pair_sign: (q_1*q_2) < 0
-    lep_iso: iso_1 < 0.15
+    # -------------------------------------------
+    lep_mt: (mt_1 < 70)
+    nbtag: (nbtag >= 0)
+    tau_pair_sign: ((q_1*q_2) < 0)
+    lep_iso: ((iso_1 > 0.0) && (iso_1 < 0.15))
+    # -------------------------------------------
     no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
+  AR_cuts:
     had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
+    # -------------------------------------------
+    lep_mt: (mt_1 < 70)
+    nbtag: (nbtag >= 0)
+    tau_pair_sign: ((q_1*q_2) < 0)
+    lep_iso: ((iso_1 > 0.0) && (iso_1 < 0.15))
+    # -------------------------------------------
+    no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
 
   var_dependence: mt_1
   var_bins: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]

--- a/configs/smhtt_ul/2018/fake_factors_et.yaml
+++ b/configs/smhtt_ul/2018/fake_factors_et.yaml
@@ -1,134 +1,122 @@
-# This is an example config containing information for the FF calculation
-
-file_path: "/ceph/sbrommer/FFmethod/smhtt_ul/03_2023_v5"
-era: "2018"
-channel: "et" # options are et, mt, tt
-tree: "ntuple"
-
-workdir_name: "full_set_v13"
-
-use_embedding: True
-
-target_processes: 
-    QCD: 
-        split_categories:
-            njets: 
-                - "==0" 
-                - "==1"
-                - ">=2"
-        split_categories_binedges:
-            njets: [-0.5,0.5,1.5,2.5]
-
-        SRlike_cuts:
-            tau_pair_sign: "(q_1*q_2) > 0" 
-            lep_mt: "mt_1 < 50"
-            lep_iso: "(iso_1 > 0.05) && (iso_1 < 0.15)"
-            no_extra_lep: "(extramuon_veto < 0.5) && (extraelec_veto < 0.5)"
-            had_tau_id_vs_jet: "id_tau_vsJet_Tight_2 > 0.5"
-
-        ARlike_cuts:
-            tau_pair_sign: "(q_1*q_2) > 0" 
-            lep_mt: "mt_1 < 50"
-            lep_iso: "(iso_1 > 0.05) && (iso_1 < 0.15)"
-            no_extra_lep: "(extramuon_veto < 0.5) && (extraelec_veto < 0.5)"
-            had_tau_id_vs_jet: "(id_tau_vsJet_VVLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)"
-        
-        var_dependence: "pt_2"
-        var_bins: [30,32,35,40,48,70,100]
-
-    Wjets: 
-        split_categories: 
-            njets:  
-                - "==0" 
-                - "==1"
-                - ">=2"
-            deltaR_ditaupair:
-                - "<3"
-                - ">=3"
-        split_categories_binedges:
-            njets: [-0.5,0.5,1.5,2.5]
-            deltaR_ditaupair: [0.,3.,10.]
-
-        SRlike_cuts:
-            tau_pair_sign: "(q_1*q_2) < 0" 
-            nbtag: "nbtag == 0"
-            lep_mt: "mt_1 > 70"
-            lep_iso: "iso_1 < 0.15"
-            no_extra_lep: "(extramuon_veto < 0.5) && (extraelec_veto < 0.5)"
-            had_tau_id_vs_jet: "id_tau_vsJet_Tight_2 > 0.5"
-
-        ARlike_cuts:
-            tau_pair_sign: "(q_1*q_2) < 0" 
-            nbtag: "nbtag == 0"
-            lep_mt: "mt_1 > 70"
-            lep_iso: "iso_1 < 0.15"
-            no_extra_lep: "(extramuon_veto < 0.5) && (extraelec_veto < 0.5)"
-            had_tau_id_vs_jet: "(id_tau_vsJet_VVLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)"
-        
-        var_dependence: "pt_2"
-        var_bins: [30,32,38,47,60,100]
-
-    ttbar: 
-        split_categories: 
-            njets:  
-                - "<=1"
-                - ">=2"
-        split_categories_binedges:
-            njets: [-0.5,1.5,2.5]
-
-        SR_cuts:
-            tau_pair_sign: "(q_1*q_2) < 0" 
-            nbtag: "nbtag >= 1"
-            lep_iso: "iso_1 < 0.15"
-            no_extra_lep: "(extramuon_veto < 0.5) && (extraelec_veto < 0.5)"
-            had_tau_id_vs_jet: "id_tau_vsJet_Tight_2 > 0.5"
-
-        AR_cuts:
-            tau_pair_sign: "(q_1*q_2) < 0" 
-            nbtag: "nbtag >= 1"
-            lep_iso: "iso_1 < 0.15"
-            no_extra_lep: "(extramuon_veto < 0.5) && (extraelec_veto < 0.5)"
-            had_tau_id_vs_jet: "(id_tau_vsJet_VVLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)"
-
-        SRlike_cuts:
-            tau_pair_sign: "(q_1*q_2) < 0" 
-            nbtag: "nbtag >= 1"
-            lep_iso: "iso_1 < 0.15"
-            no_extra_lep: "!((extramuon_veto < 0.5) && (extraelec_veto < 0.5))"
-            had_tau_id_vs_jet: "id_tau_vsJet_Tight_2 > 0.5"
-            
-        ARlike_cuts:
-            tau_pair_sign: "(q_1*q_2) < 0" 
-            nbtag: "nbtag >= 1"
-            lep_iso: "iso_1 < 0.15"
-            no_extra_lep: "!((extramuon_veto < 0.5) && (extraelec_veto < 0.5))"
-            had_tau_id_vs_jet: "(id_tau_vsJet_VVLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)"
-        
-        var_dependence: "pt_2"
-        var_bins: [30,32,35,38,41,44,52,70,100]
-
-process_fractions:
-    processes: ["QCD", "Wjets", "ttbar_J"]
-
+channel: et
+tree: ntuple
+use_embedding: true
+target_processes:
+  QCD:
     split_categories:
-        njets:
-            - "==0"
-            - "==1"
-            - ">=2"
+      njets:
+        - "==0"
+        - "==1"
+        - ">=2"
     split_categories_binedges:
-        njets: [-0.5,0.5,1.5,2.5]
+      njets: [-0.5, 0.5, 1.5, 2.5]
 
-    AR_cuts:
-        tau_pair_sign: "(q_1*q_2) < 0" 
-        lep_iso: "iso_1 < 0.15"
-        no_extra_lep: "(extramuon_veto < 0.5) && (extraelec_veto < 0.5)"
-        had_tau_id_vs_jet: "(id_tau_vsJet_VVLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)"
+    SRlike_cuts:
+      tau_pair_sign: (q_1*q_2) > 0
+      lep_mt: mt_1 < 50
+      lep_iso: (iso_1 > 0.05) && (iso_1 < 0.15)
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
+      had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
+
+    ARlike_cuts:
+      tau_pair_sign: (q_1*q_2) > 0
+      lep_mt: mt_1 < 50
+      lep_iso: (iso_1 > 0.05) && (iso_1 < 0.15)
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
+      had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
+
+    var_dependence: pt_2
+    var_bins: [30, 32, 35, 40, 48, 70, 100]
+
+  Wjets:
+    split_categories:
+      deltaR_ditaupair:
+        - "<3"
+        - ">=3"
+      njets:
+        - "==0"
+        - "==1"
+        - ">=2"
+    split_categories_binedges:
+      deltaR_ditaupair: [0.0, 3.0, 10.0]
+      njets: [-0.5, 0.5, 1.5, 2.5]
+
+    SRlike_cuts:
+      tau_pair_sign: (q_1*q_2) < 0
+      lep_mt: mt_1 > 70
+      lep_iso: iso_1 < 0.15
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
+      had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
+      nbtag: nbtag == 0
+    ARlike_cuts:
+      tau_pair_sign: (q_1*q_2) < 0
+      lep_mt: mt_1 > 70
+      lep_iso: iso_1 < 0.15
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
+      had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
+      nbtag: nbtag == 0
+
+    var_dependence: pt_2
+    var_bins: [30, 32, 38, 47, 60, 100]
+
+  ttbar:
+    split_categories:
+      njets:
+        - "<=1"
+        - ">=2"
+    split_categories_binedges:
+      njets: [-0.5, 1.5, 2.5]
 
     SR_cuts:
-        tau_pair_sign: "(q_1*q_2) < 0" 
-        lep_iso: "iso_1 < 0.15"
-        no_extra_lep: "(extramuon_veto < 0.5) && (extraelec_veto < 0.5)"
-        had_tau_id_vs_jet: "id_tau_vsJet_Tight_2 > 0.5"
+      tau_pair_sign: (q_1*q_2) < 0
+      lep_iso: iso_1 < 0.15
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
+      had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
+      nbtag: nbtag >= 1
+    AR_cuts:
+      tau_pair_sign: (q_1*q_2) < 0
+      lep_iso: iso_1 < 0.15
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
+      had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
+      nbtag: nbtag >= 1
 
-    var_dependence: "mt_1"
-    var_bins: [0,10,20,30,40,50,60,70,80,90,100]
+    SRlike_cuts:
+      tau_pair_sign: (q_1*q_2) < 0
+      lep_iso: iso_1 < 0.15
+      no_extra_lep: "!((extramuon_veto < 0.5) && (extraelec_veto < 0.5))"
+      had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
+      nbtag: nbtag >= 1
+    ARlike_cuts:
+      tau_pair_sign: (q_1*q_2) < 0
+      lep_iso: iso_1 < 0.15
+      no_extra_lep: "!((extramuon_veto < 0.5) && (extraelec_veto < 0.5))"
+      had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
+      nbtag: nbtag >= 1
+
+    var_dependence: pt_2
+    var_bins: [30, 32, 35, 38, 41, 44, 52, 70, 100]
+
+process_fractions:
+  processes: ["QCD", "Wjets", "ttbar_J"]
+
+  split_categories:
+    njets:
+      - "==0"
+      - "==1"
+      - ">=2"
+  split_categories_binedges:
+    njets: [-0.5, 0.5, 1.5, 2.5]
+
+  SR_cuts:
+    tau_pair_sign: (q_1*q_2) < 0
+    lep_iso: iso_1 < 0.15
+    no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
+    had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
+  AR_cuts:
+    tau_pair_sign: (q_1*q_2) < 0
+    lep_iso: iso_1 < 0.15
+    no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
+    had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
+
+  var_dependence: mt_1
+  var_bins: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]

--- a/configs/smhtt_ul/2018/fake_factors_et.yaml
+++ b/configs/smhtt_ul/2018/fake_factors_et.yaml
@@ -30,8 +30,8 @@ target_processes:
       no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
 
     var_dependence: pt_2
-    var_bins: [30, 35, 40, 50, 60, 75, 90, 115]
-    ff_type: "poly1"
+    var_bins: [30, 35, 40, 50, 65, 80, 115]
+    fit_option: ["poly_0", "poly_1", "poly_2", "poly_3", "poly_4", "poly_5"]
 
   Wjets:
     split_categories:
@@ -66,7 +66,8 @@ target_processes:
       no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
 
     var_dependence: pt_2
-    var_bins: [30, 35, 40, 50, 60, 75, 90, 115]
+    var_bins: [30, 35, 40, 50, 65, 80, 115]
+    fit_option: ["poly_0", "poly_1", "poly_2", "poly_3", "poly_4", "poly_5"]
 
   ttbar:
     split_categories:
@@ -117,7 +118,8 @@ target_processes:
       no_extra_lep: "!((extramuon_veto < 0.5) && (extraelec_veto < 0.5))"
 
     var_dependence: pt_2
-    var_bins: [30, 35, 40, 50, 60, 75, 90, 115]
+    var_bins: [30, 35, 40, 50, 65, 80, 115]
+    fit_option: ["poly_0", "poly_1", "poly_2", "poly_3", "poly_4", "poly_5"]
 
 process_fractions:
   processes: ["QCD", "Wjets", "ttbar_J"]

--- a/configs/smhtt_ul/2018/fake_factors_mt.yaml
+++ b/configs/smhtt_ul/2018/fake_factors_mt.yaml
@@ -1,6 +1,4 @@
 channel: mt
-tree: ntuple
-use_embedding: true
 target_processes:
   QCD:
     split_categories:

--- a/configs/smhtt_ul/2018/fake_factors_mt.yaml
+++ b/configs/smhtt_ul/2018/fake_factors_mt.yaml
@@ -7,54 +7,66 @@ target_processes:
         - "==1"
         - ">=2"
     split_categories_binedges:
-      njets: [-0.5, 0.5, 1.5, 2.5]
+      njets: [-0.5, 0.5, 1.5, 12.5]
 
     SRlike_cuts:
       had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
-      lep_iso: (iso_1 > 0.05) && (iso_1 < 0.15)
-      lep_mt: mt_1 < 50
+      # -------------------------------------------
+      lep_mt: (mt_1 < 50)
+      nbtag: (nbtag >= 0)
+      tau_pair_sign: ((q_1*q_2) > 0)
+      lep_iso: ((iso_1 > 0.05) && (iso_1 < 0.15))
+      # -------------------------------------------
       no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)
-      tau_pair_sign: (q_1*q_2) > 0
+
     ARlike_cuts:
       had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
-      lep_iso: (iso_1 > 0.05) && (iso_1 < 0.15)
-      lep_mt: mt_1 < 50
+      # -------------------------------------------
+      lep_mt: (mt_1 < 50)
+      nbtag: (nbtag >= 0)
+      tau_pair_sign: ((q_1*q_2) > 0)
+      lep_iso: ((iso_1 > 0.05) && (iso_1 < 0.15))
+      # -------------------------------------------
       no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)
-      tau_pair_sign: (q_1*q_2) > 0
 
     var_dependence: pt_2
-    var_bins: [30, 35, 40, 45, 50, 55, 60, 70, 80, 100]
+    var_bins: [30, 35, 40, 50, 60, 75, 90, 115]
 
   Wjets:
     split_categories:
-      deltaR_ditaupair:
-        - "<3"
-        - ">=3"
       njets:
         - "==0"
         - "==1"
         - ">=2"
+      deltaR_ditaupair:
+        - "<3"
+        - ">=3"
     split_categories_binedges:
+      njets: [-0.5, 0.5, 1.5, 12.5]
       deltaR_ditaupair: [0.0, 3.0, 10.0]
-      njets: [-0.5, 0.5, 1.5, 2.5]
 
     SRlike_cuts:
       had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
-      lep_iso: iso_1 < 0.15
-      lep_mt: mt_1 > 70
-      nbtag: nbtag == 0
+      # -------------------------------------------
+      lep_mt: (mt_1 > 70)
+      nbtag: (nbtag == 0)
+      tau_pair_sign: ((q_1*q_2) < 0)
+      lep_iso: ((iso_1 > 0.0) && (iso_1 < 0.15))
+      # -------------------------------------------
       no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)
-      tau_pair_sign: (q_1*q_2) < 0
+
     ARlike_cuts:
       had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
-      lep_iso: iso_1 < 0.15
-      lep_mt: mt_1 > 70
-      nbtag: nbtag == 0
+      # -------------------------------------------
+      lep_mt: (mt_1 > 70)
+      nbtag: (nbtag == 0)
+      tau_pair_sign: ((q_1*q_2) < 0)
+      lep_iso: ((iso_1 > 0.0) && (iso_1 < 0.15))
+      # -------------------------------------------
       no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)
-      tau_pair_sign: (q_1*q_2) < 0
 
     var_dependence: pt_2
-    var_bins: [30, 35, 40, 45, 50, 55, 60, 70, 80, 100]
+    var_bins: [30, 35, 40, 50, 60, 75, 90, 115]
 
   ttbar:
     split_categories:
@@ -62,36 +74,50 @@ target_processes:
         - "<=1"
         - ">=2"
     split_categories_binedges:
-      njets: [-0.5, 1.5, 2.5]
+      njets: [-0.5, 1.5, 12.5]
 
     SR_cuts:
       had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
-      lep_iso: iso_1 < 0.15
-      nbtag: nbtag >= 1
+      # -------------------------------------------
+      lep_mt: (mt_1 < 70)
+      nbtag: (nbtag >= 0)
+      tau_pair_sign: ((q_1*q_2) < 0)
+      lep_iso: ((iso_1 > 0.0) && (iso_1 < 0.15))
+      # -------------------------------------------
       no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)
-      tau_pair_sign: (q_1*q_2) < 0
+
     AR_cuts:
       had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
-      lep_iso: iso_1 < 0.15
-      nbtag: nbtag >= 1
+      # -------------------------------------------
+      lep_mt: (mt_1 < 70)
+      nbtag: (nbtag >= 0)
+      tau_pair_sign: ((q_1*q_2) < 0)
+      lep_iso: ((iso_1 > 0.0) && (iso_1 < 0.15))
+      # -------------------------------------------
       no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)
-      tau_pair_sign: (q_1*q_2) < 0
 
     SRlike_cuts:
       had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
-      lep_iso: iso_1 < 0.15
-      nbtag: nbtag >= 1
+      # -------------------------------------------
+      lep_mt: (mt_1 < 70)
+      nbtag: (nbtag >= 0)
+      tau_pair_sign: ((q_1*q_2) < 0)
+      lep_iso: ((iso_1 > 0.0) && (iso_1 < 0.15))
+      # -------------------------------------------
       no_extra_lep: '!((extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5))'
-      tau_pair_sign: (q_1*q_2) < 0
+
     ARlike_cuts:
       had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
-      lep_iso: iso_1 < 0.15
-      nbtag: nbtag >= 1
+      # -------------------------------------------
+      lep_mt: (mt_1 < 70)
+      nbtag: (nbtag >= 0)
+      tau_pair_sign: ((q_1*q_2) < 0)
+      lep_iso: ((iso_1 > 0.0) && (iso_1 < 0.15))
+      # -------------------------------------------
       no_extra_lep: '!((extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5))'
-      tau_pair_sign: (q_1*q_2) < 0
 
     var_dependence: pt_2
-    var_bins: [30, 35, 40, 45, 50, 55, 60, 70, 80, 100]
+    var_bins: [30, 35, 40, 50, 60, 75, 90, 115]
 
 process_fractions:
   processes: ["QCD", "Wjets", "ttbar_J"]
@@ -102,19 +128,27 @@ process_fractions:
       - "==1"
       - ">=2"
   split_categories_binedges:
-    njets: [-0.5, 0.5, 1.5, 2.5]
+    njets: [-0.5, 0.5, 1.5, 12.5]
 
   SR_cuts:
     had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
-    lep_iso: iso_1 < 0.15
+    # -------------------------------------------
+    lep_mt: (mt_1 < 70)
+    nbtag: (nbtag >= 0)
+    tau_pair_sign: ((q_1*q_2) < 0)
+    lep_iso: ((iso_1 > 0.0) && (iso_1 < 0.15))
+    # -------------------------------------------
     no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)
-    tau_pair_sign: (q_1*q_2) < 0
   AR_cuts:
     had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
-    lep_iso: iso_1 < 0.15
+    # -------------------------------------------
+    lep_mt: (mt_1 < 70)
+    nbtag: (nbtag >= 0)
+    tau_pair_sign: ((q_1*q_2) < 0)
+    lep_iso: ((iso_1 > 0.0) && (iso_1 < 0.15))
+    # -------------------------------------------
     no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)
-    tau_pair_sign: (q_1*q_2) < 0
 
   var_dependence: mt_1
-  var_bins: [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70]
+  var_bins: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
 

--- a/configs/smhtt_ul/2018/fake_factors_mt.yaml
+++ b/configs/smhtt_ul/2018/fake_factors_mt.yaml
@@ -30,7 +30,8 @@ target_processes:
       no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)
 
     var_dependence: pt_2
-    var_bins: [30, 35, 40, 50, 60, 75, 90, 115]
+    var_bins: [30, 35, 40, 50, 65, 80, 115]
+    fit_option: ["poly_0", "poly_1", "poly_2", "poly_3", "poly_4", "poly_5"]
 
   Wjets:
     split_categories:
@@ -66,7 +67,8 @@ target_processes:
       no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)
 
     var_dependence: pt_2
-    var_bins: [30, 35, 40, 50, 60, 75, 90, 115]
+    var_bins: [30, 35, 40, 50, 65, 80, 115]
+    fit_option: ["poly_0", "poly_1", "poly_2", "poly_3", "poly_4", "poly_5"]
 
   ttbar:
     split_categories:
@@ -117,7 +119,8 @@ target_processes:
       no_extra_lep: '!((extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5))'
 
     var_dependence: pt_2
-    var_bins: [30, 35, 40, 50, 60, 75, 90, 115]
+    var_bins: [30, 35, 40, 50, 65, 80, 115]
+    fit_option: ["poly_0", "poly_1", "poly_2", "poly_3", "poly_4", "poly_5"]
 
 process_fractions:
   processes: ["QCD", "Wjets", "ttbar_J"]

--- a/configs/smhtt_ul/2018/fake_factors_mt.yaml
+++ b/configs/smhtt_ul/2018/fake_factors_mt.yaml
@@ -1,134 +1,122 @@
-# This is an example config containing information for the FF calculation
-
-file_path: "/ceph/sbrommer/FFmethod/smhtt_ul/03_2023_v6"
-era: "2018"
-channel: "mt" # options are et, mt, tt
-tree: "ntuple"
-
-workdir_name: "full_set_v13"
-
-use_embedding: True
-
+channel: mt
+tree: ntuple
+use_embedding: true
 target_processes:
-    QCD: 
-        split_categories:
-            njets:
-                - "==0"
-                - "==1"
-                - ">=2"
-        split_categories_binedges:
-            njets: [-0.5,0.5,1.5,2.5]
-
-        SRlike_cuts:
-            tau_pair_sign: "(q_1*q_2) > 0" 
-            lep_mt: "mt_1 < 50"
-            lep_iso: "(iso_1 > 0.05) && (iso_1 < 0.15)"
-            no_extra_lep: "(extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)"
-            had_tau_id_vs_jet: "id_tau_vsJet_Tight_2 > 0.5"
-
-        ARlike_cuts:
-            tau_pair_sign: "(q_1*q_2) > 0" 
-            lep_mt: "mt_1 < 50"
-            lep_iso: "(iso_1 > 0.05) && (iso_1 < 0.15)"
-            no_extra_lep: "(extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)"
-            had_tau_id_vs_jet: "(id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)"
-        
-        var_dependence: "pt_2"
-        var_bins: [30,35,40,45,50,55,60,70,80,100]
-
-    Wjets:
-        split_categories:
-            njets:
-                - "==0" 
-                - "==1"
-                - ">=2"
-            deltaR_ditaupair:
-                - "<3"
-                - ">=3"
-        split_categories_binedges:
-            njets: [-0.5,0.5,1.5,2.5]
-            deltaR_ditaupair: [0.,3.,10.]
-
-        SRlike_cuts:
-            tau_pair_sign: "(q_1*q_2) < 0" 
-            nbtag: "nbtag == 0"
-            lep_mt: "mt_1 > 70"
-            lep_iso: "iso_1 < 0.15"
-            no_extra_lep: "(extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)"
-            had_tau_id_vs_jet: "id_tau_vsJet_Tight_2 > 0.5"
-
-        ARlike_cuts:
-            tau_pair_sign: "(q_1*q_2) < 0" 
-            nbtag: "nbtag == 0"
-            lep_mt: "mt_1 > 70"
-            lep_iso: "iso_1 < 0.15"
-            no_extra_lep: "(extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)"
-            had_tau_id_vs_jet: "(id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)"
-        
-        var_dependence: "pt_2"
-        var_bins: [30,35,40,45,50,55,60,70,80,100]
-
-    ttbar: 
-        split_categories: 
-            njets:
-                - "<=1"
-                - ">=2"
-        split_categories_binedges:
-            njets: [-0.5,1.5,2.5]
-
-        SR_cuts:
-            tau_pair_sign: "(q_1*q_2) < 0" 
-            nbtag: "nbtag >= 1"
-            lep_iso: "iso_1 < 0.15"
-            no_extra_lep: "(extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)"
-            had_tau_id_vs_jet: "id_tau_vsJet_Tight_2 > 0.5"
-
-        AR_cuts:
-            tau_pair_sign: "(q_1*q_2) < 0" 
-            nbtag: "nbtag >= 1"
-            lep_iso: "iso_1 < 0.15"
-            no_extra_lep: "(extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)"
-            had_tau_id_vs_jet: "(id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)"
-
-        SRlike_cuts:
-            tau_pair_sign: "(q_1*q_2) < 0" 
-            nbtag: "nbtag >= 1"
-            lep_iso: "iso_1 < 0.15"
-            no_extra_lep: "!((extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5))"
-            had_tau_id_vs_jet: "id_tau_vsJet_Tight_2 > 0.5"
-            
-        ARlike_cuts:
-            tau_pair_sign: "(q_1*q_2) < 0" 
-            nbtag: "nbtag >= 1"
-            lep_iso: "iso_1 < 0.15"
-            no_extra_lep: "!((extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5))"
-            had_tau_id_vs_jet: "(id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)"
-        
-        var_dependence: "pt_2"
-        var_bins: [30,35,40,45,50,55,60,70,80,100]
-
-process_fractions:
-    processes: ["QCD", "Wjets", "ttbar_J"]
-
+  QCD:
     split_categories:
-        njets:
-            - "==0"
-            - "==1"
-            - ">=2"
+      njets:
+        - "==0"
+        - "==1"
+        - ">=2"
     split_categories_binedges:
-        njets: [-0.5,0.5,1.5,2.5]
+      njets: [-0.5, 0.5, 1.5, 2.5]
 
-    AR_cuts:
-        tau_pair_sign: "(q_1*q_2) < 0" 
-        lep_iso: "iso_1 < 0.15"
-        no_extra_lep: "(extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)"
-        had_tau_id_vs_jet: "(id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)"
+    SRlike_cuts:
+      had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
+      lep_iso: (iso_1 > 0.05) && (iso_1 < 0.15)
+      lep_mt: mt_1 < 50
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)
+      tau_pair_sign: (q_1*q_2) > 0
+    ARlike_cuts:
+      had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
+      lep_iso: (iso_1 > 0.05) && (iso_1 < 0.15)
+      lep_mt: mt_1 < 50
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)
+      tau_pair_sign: (q_1*q_2) > 0
+
+    var_dependence: pt_2
+    var_bins: [30, 35, 40, 45, 50, 55, 60, 70, 80, 100]
+
+  Wjets:
+    split_categories:
+      deltaR_ditaupair:
+        - "<3"
+        - ">=3"
+      njets:
+        - "==0"
+        - "==1"
+        - ">=2"
+    split_categories_binedges:
+      deltaR_ditaupair: [0.0, 3.0, 10.0]
+      njets: [-0.5, 0.5, 1.5, 2.5]
+
+    SRlike_cuts:
+      had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
+      lep_iso: iso_1 < 0.15
+      lep_mt: mt_1 > 70
+      nbtag: nbtag == 0
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)
+      tau_pair_sign: (q_1*q_2) < 0
+    ARlike_cuts:
+      had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
+      lep_iso: iso_1 < 0.15
+      lep_mt: mt_1 > 70
+      nbtag: nbtag == 0
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)
+      tau_pair_sign: (q_1*q_2) < 0
+
+    var_dependence: pt_2
+    var_bins: [30, 35, 40, 45, 50, 55, 60, 70, 80, 100]
+
+  ttbar:
+    split_categories:
+      njets:
+        - "<=1"
+        - ">=2"
+    split_categories_binedges:
+      njets: [-0.5, 1.5, 2.5]
 
     SR_cuts:
-        tau_pair_sign: "(q_1*q_2) < 0" 
-        lep_iso: "iso_1 < 0.15"
-        no_extra_lep: "(extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)"
-        had_tau_id_vs_jet: "id_tau_vsJet_Tight_2 > 0.5"
+      had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
+      lep_iso: iso_1 < 0.15
+      nbtag: nbtag >= 1
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)
+      tau_pair_sign: (q_1*q_2) < 0
+    AR_cuts:
+      had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
+      lep_iso: iso_1 < 0.15
+      nbtag: nbtag >= 1
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)
+      tau_pair_sign: (q_1*q_2) < 0
 
-    var_dependence: "mt_1"
-    var_bins: [0,5,10,15,20,25,30,35,40,45,50,55,60,65,70]
+    SRlike_cuts:
+      had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
+      lep_iso: iso_1 < 0.15
+      nbtag: nbtag >= 1
+      no_extra_lep: '!((extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5))'
+      tau_pair_sign: (q_1*q_2) < 0
+    ARlike_cuts:
+      had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
+      lep_iso: iso_1 < 0.15
+      nbtag: nbtag >= 1
+      no_extra_lep: '!((extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5))'
+      tau_pair_sign: (q_1*q_2) < 0
+
+    var_dependence: pt_2
+    var_bins: [30, 35, 40, 45, 50, 55, 60, 70, 80, 100]
+
+process_fractions:
+  processes: ["QCD", "Wjets", "ttbar_J"]
+
+  split_categories:
+    njets:
+      - "==0"
+      - "==1"
+      - ">=2"
+  split_categories_binedges:
+    njets: [-0.5, 0.5, 1.5, 2.5]
+
+  SR_cuts:
+    had_tau_id_vs_jet: id_tau_vsJet_Tight_2 > 0.5
+    lep_iso: iso_1 < 0.15
+    no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)
+    tau_pair_sign: (q_1*q_2) < 0
+  AR_cuts:
+    had_tau_id_vs_jet: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
+    lep_iso: iso_1 < 0.15
+    no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5) && (dimuon_veto < 0.5)
+    tau_pair_sign: (q_1*q_2) < 0
+
+  var_dependence: mt_1
+  var_bins: [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70]
+

--- a/configs/smhtt_ul/2018/fake_factors_tt.yaml
+++ b/configs/smhtt_ul/2018/fake_factors_tt.yaml
@@ -7,19 +7,26 @@ target_processes:
         - "==1"
         - ">=2"
     split_categories_binedges:
-      njets: [-0.5, 0.5, 1.5, 2.5]
+      njets: [-0.5, 0.5, 1.5, 12.5]
 
     SRlike_cuts:
-      tau_pair_sign: (q_1*q_2) > 0
       had_tau_id_vs_jet_1: id_tau_vsJet_Tight_1 > 0.5
       had_tau_id_vs_jet_2: id_tau_vsJet_Tight_2 > 0.5
-    ARlike_cuts:
+      # -------------------------------------------
       tau_pair_sign: (q_1*q_2) > 0
+      # -------------------------------------------
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
+
+    ARlike_cuts:
       had_tau_id_vs_jet_1: (id_tau_vsJet_VLoose_1 > 0.5) && (id_tau_vsJet_Tight_1 < 0.5)
       had_tau_id_vs_jet_2: id_tau_vsJet_Tight_2 > 0.5
+      # -------------------------------------------
+      tau_pair_sign: (q_1*q_2) > 0
+      # -------------------------------------------
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
 
     var_dependence: pt_1
-    var_bins: [40, 48, 70, 100]
+    var_bins: [40, 50, 60, 70, 100]
 
   QCD_subleading:
     split_categories:
@@ -28,19 +35,26 @@ target_processes:
         - "==1"
         - ">=2"
     split_categories_binedges:
-      njets: [-0.5, 0.5, 1.5, 2.5]
+      njets: [-0.5, 0.5, 1.5, 12.5]
 
     SRlike_cuts:
-      tau_pair_sign: (q_1*q_2) > 0
       had_tau_id_vs_jet_1: id_tau_vsJet_Tight_1 > 0.5
       had_tau_id_vs_jet_2: id_tau_vsJet_Tight_2 > 0.5
-    ARlike_cuts:
+      # -------------------------------------------
       tau_pair_sign: (q_1*q_2) > 0
+      # -------------------------------------------
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
+
+    ARlike_cuts:
       had_tau_id_vs_jet_1: id_tau_vsJet_Tight_1 > 0.5
       had_tau_id_vs_jet_2: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
+      # -------------------------------------------
+      tau_pair_sign: (q_1*q_2) > 0
+      # -------------------------------------------
+      no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
 
     var_dependence: pt_2
-    var_bins: [40, 48, 70, 100]
+    var_bins: [40, 50, 60, 70, 100]
 
 process_fractions:
   processes:
@@ -52,21 +66,26 @@ process_fractions:
       - "==1"
       - ">=2"
   split_categories_binedges:
-    njets: [-0.5, 0.5, 1.5, 2.5]
+    njets: [-0.5, 0.5, 1.5, 12.5]
 
   SR_cuts:
-    tau_pair_sign: (q_1*q_2) < 0
-    no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
     had_tau_id_vs_jet_1: id_tau_vsJet_Tight_1 > 0.5
     had_tau_id_vs_jet_2: id_tau_vsJet_Tight_2 > 0.5
-  AR_cuts:
+    # -------------------------------------------
     tau_pair_sign: (q_1*q_2) < 0
+    # -------------------------------------------
     no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
+
+  AR_cuts:
     had_tau_id_vs_jet_1: (id_tau_vsJet_VLoose_1 > 0.5) && (id_tau_vsJet_Tight_1 < 0.5)
     had_tau_id_vs_jet_2: id_tau_vsJet_Tight_2 < 0.5
+    # -------------------------------------------
+    tau_pair_sign: (q_1*q_2) < 0
+    # -------------------------------------------
+    no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
 
   var_dependence: m_vis
-  var_bins: [0, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 200]
+  var_bins: [40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 200]
 
 process_fractions_subleading:
   processes: ["QCD"]
@@ -76,19 +95,29 @@ process_fractions_subleading:
       - "==0"
       - "==1"
       - ">=2"
+    tau_decaymode_1:
+        - "==0"
+        - "==1"
+        - "==10"
+        - "==11"
   split_categories_binedges:
-    njets: [-0.5, 0.5, 1.5, 2.5]
+    njets: [-0.5, 0.5, 1.5, 12.5]
 
   SR_cuts:
-    tau_pair_sign: (q_1*q_2) < 0
-    no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
     had_tau_id_vs_jet_1: id_tau_vsJet_Tight_1 > 0.5
     had_tau_id_vs_jet_2: id_tau_vsJet_Tight_2 > 0.5
+    # -------------------------------------------
+    tau_pair_sign: (q_1*q_2) < 0
+    # -------------------------------------------
+    no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
+
   AR_cuts:
-    tau_pair_sign: "(q_1*q_2) < 0" 
-    no_extra_lep: "(extramuon_veto < 0.5) && (extraelec_veto < 0.5)"
     had_tau_id_vs_jet_1: id_tau_vsJet_Tight_1 < 0.5
     had_tau_id_vs_jet_2: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
+    # -------------------------------------------
+    tau_pair_sign: (q_1*q_2) < 0
+    # -------------------------------------------
+    no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
 
   var_dependence: m_vis
-  var_bins: [0, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 200]
+  var_bins: [40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 175, 200, 225]

--- a/configs/smhtt_ul/2018/fake_factors_tt.yaml
+++ b/configs/smhtt_ul/2018/fake_factors_tt.yaml
@@ -27,6 +27,7 @@ target_processes:
 
     var_dependence: pt_1
     var_bins: [40, 50, 60, 70, 100]
+    fit_option: ["poly_0", "poly_1", "poly_2", "poly_3", "poly_4", "poly_5"]
 
   QCD_subleading:
     split_categories:
@@ -55,6 +56,7 @@ target_processes:
 
     var_dependence: pt_2
     var_bins: [40, 50, 60, 70, 100]
+    fit_option: ["poly_0", "poly_1", "poly_2", "poly_3", "poly_4", "poly_5"]
 
 process_fractions:
   processes:

--- a/configs/smhtt_ul/2018/fake_factors_tt.yaml
+++ b/configs/smhtt_ul/2018/fake_factors_tt.yaml
@@ -1,80 +1,96 @@
-# This is an example config containing information for the FF calculation
-
-file_path: "/ceph/sbrommer/FFmethod/smhtt_ul/03_2023_v2"
-era: "2018"
-channel: "tt" # options are et, mt, tt
-tree: "ntuple"
-
-workdir_name: "full_set_v2_mc"
-
-use_embedding: False
-
+channel: tt
+tree: ntuple
+use_embedding: true
 target_processes:
-    QCD: 
-        split_categories:
-            njets: 
-                - "==0" 
-                - "==1"
-                - ">=2"
-        split_categories_binedges:
-            njets: [-0.5,0.5,1.5,2.5]
+  QCD:
+    split_categories:
+      njets:
+        - "==0"
+        - "==1"
+        - ">=2"
+    split_categories_binedges:
+      njets: [-0.5, 0.5, 1.5, 2.5]
 
-        SRlike_cuts:
-            tau_pair_sign: "(q_1*q_2) > 0" 
-            had_tau_id_vs_jet_1: "id_tau_vsJet_Tight_1 > 0.5"
-            had_tau_id_vs_jet_2: "id_tau_vsJet_Tight_2 > 0.5"
+    SRlike_cuts:
+      tau_pair_sign: (q_1*q_2) > 0
+      had_tau_id_vs_jet_1: id_tau_vsJet_Tight_1 > 0.5
+      had_tau_id_vs_jet_2: id_tau_vsJet_Tight_2 > 0.5
+    ARlike_cuts:
+      tau_pair_sign: (q_1*q_2) > 0
+      had_tau_id_vs_jet_1: (id_tau_vsJet_VLoose_1 > 0.5) && (id_tau_vsJet_Tight_1 < 0.5)
+      had_tau_id_vs_jet_2: id_tau_vsJet_Tight_2 > 0.5
 
-        ARlike_cuts:
-            tau_pair_sign: "(q_1*q_2) > 0" 
-            had_tau_id_vs_jet_1: "(id_tau_vsJet_VVLoose_1 > 0.5) && (id_tau_vsJet_Tight_1 < 0.5)"
-            had_tau_id_vs_jet_2: "id_tau_vsJet_Tight_2 > 0.5"
+    var_dependence: pt_1
+    var_bins: [40, 48, 70, 100]
 
-        var_dependence: "pt_1"
-        var_bins: [30,32,35,40,48,70,100]
+  QCD_subleading:
+    split_categories:
+      njets:
+        - "==0"
+        - "==1"
+        - ">=2"
+    split_categories_binedges:
+      njets: [-0.5, 0.5, 1.5, 2.5]
 
-    QCD_subleading: 
-        split_categories:
-            njets: 
-                - "==0" 
-                - "==1"
-                - ">=2"
-        split_categories_binedges:
-            njets: [-0.5,0.5,1.5,2.5]
+    SRlike_cuts:
+      tau_pair_sign: (q_1*q_2) > 0
+      had_tau_id_vs_jet_1: id_tau_vsJet_Tight_1 > 0.5
+      had_tau_id_vs_jet_2: id_tau_vsJet_Tight_2 > 0.5
+    ARlike_cuts:
+      tau_pair_sign: (q_1*q_2) > 0
+      had_tau_id_vs_jet_1: id_tau_vsJet_Tight_1 > 0.5
+      had_tau_id_vs_jet_2: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
 
-        SRlike_cuts:
-            tau_pair_sign: "(q_1*q_2) > 0" 
-            had_tau_id_vs_jet_1: "id_tau_vsJet_Tight_1 > 0.5"
-            had_tau_id_vs_jet_2: "id_tau_vsJet_Tight_2 > 0.5"
-
-        ARlike_cuts:
-            tau_pair_sign: "(q_1*q_2) > 0" 
-            had_tau_id_vs_jet_1: "id_tau_vsJet_Tight_1 > 0.5"
-            had_tau_id_vs_jet_2: "(id_tau_vsJet_VVLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)"
-
-        var_dependence: "pt_2"
-        var_bins: [30,32,35,40,48,70,100]
-
+    var_dependence: pt_2
+    var_bins: [40, 48, 70, 100]
 
 process_fractions:
-    processes: ["QCD"]
+  processes:
+    - "QCD"
 
-    split_categories:
-        njets:
-            - "==0"
-            - "==1"
-            - ">=2"
-    split_categories_binedges:
-        njets: [-0.5,0.5,1.5,2.5]
+  split_categories:
+    njets:
+      - "==0"
+      - "==1"
+      - ">=2"
+  split_categories_binedges:
+    njets: [-0.5, 0.5, 1.5, 2.5]
 
-    AR_cuts:
-        tau_pair_sign: "(q_1*q_2) < 0" 
-        had_tau_id_vs_jet_1: "(id_tau_vsJet_VVLoose_1 > 0.5) && (id_tau_vsJet_Tight_1 < 0.5)"
-        had_tau_id_vs_jet_2: "(id_tau_vsJet_VVLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)"
+  SR_cuts:
+    tau_pair_sign: (q_1*q_2) < 0
+    no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
+    had_tau_id_vs_jet_1: id_tau_vsJet_Tight_1 > 0.5
+    had_tau_id_vs_jet_2: id_tau_vsJet_Tight_2 > 0.5
+  AR_cuts:
+    tau_pair_sign: (q_1*q_2) < 0
+    no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
+    had_tau_id_vs_jet_1: (id_tau_vsJet_VLoose_1 > 0.5) && (id_tau_vsJet_Tight_1 < 0.5)
+    had_tau_id_vs_jet_2: id_tau_vsJet_Tight_2 < 0.5
 
-    SR_cuts:
-        tau_pair_sign: "(q_1*q_2) < 0" 
-        had_tau_id_vs_jet_1: "id_tau_vsJet_Tight_1 > 0.5"
-        had_tau_id_vs_jet_2: "id_tau_vsJet_Tight_2 > 0.5"
+  var_dependence: m_vis
+  var_bins: [0, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 200]
 
-    var_dependence: "m_vis"
-    var_bins: [0,40,50,60,70,80,90,100,110,120,130,140,150,200]
+process_fractions_subleading:
+  processes: ["QCD"]
+
+  split_categories:
+    njets:
+      - "==0"
+      - "==1"
+      - ">=2"
+  split_categories_binedges:
+    njets: [-0.5, 0.5, 1.5, 2.5]
+
+  SR_cuts:
+    tau_pair_sign: (q_1*q_2) < 0
+    no_extra_lep: (extramuon_veto < 0.5) && (extraelec_veto < 0.5)
+    had_tau_id_vs_jet_1: id_tau_vsJet_Tight_1 > 0.5
+    had_tau_id_vs_jet_2: id_tau_vsJet_Tight_2 > 0.5
+  AR_cuts:
+    tau_pair_sign: "(q_1*q_2) < 0" 
+    no_extra_lep: "(extramuon_veto < 0.5) && (extraelec_veto < 0.5)"
+    had_tau_id_vs_jet_1: id_tau_vsJet_Tight_1 < 0.5
+    had_tau_id_vs_jet_2: (id_tau_vsJet_VLoose_2 > 0.5) && (id_tau_vsJet_Tight_2 < 0.5)
+
+  var_dependence: m_vis
+  var_bins: [0, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 200]

--- a/configs/smhtt_ul/2018/fake_factors_tt.yaml
+++ b/configs/smhtt_ul/2018/fake_factors_tt.yaml
@@ -1,6 +1,4 @@
 channel: tt
-tree: ntuple
-use_embedding: true
 target_processes:
   QCD:
     split_categories:

--- a/configs/smhtt_ul/2018/preselection_et.yaml
+++ b/configs/smhtt_ul/2018/preselection_et.yaml
@@ -67,12 +67,10 @@ processes:
       - L
 event_selection:
   had_tau_decay_mode: (tau_decaymode_2 == 0) || (tau_decaymode_2 == 1) || (tau_decaymode_2 == 10) || (tau_decaymode_2 == 11)
-  had_tau_eta: abs(eta_2) < 2.3
   had_tau_id_vs_ele: id_tau_vsEle_Tight_2 > 0.5
   had_tau_id_vs_mu: id_tau_vsMu_VLoose_2 > 0.5
   had_tau_pt: pt_2 > 30
-  lep_pt: pt_1 > 33
-  single_trigger: (trg_single_ele32 > 0.5) || (trg_single_ele35 > 0.5)
+  lep_pt: ((pt_1 > 33) && ((trg_single_ele35  > 0.5) || (trg_single_ele32  > 0.5)))
 mc_weights:
   Top_pt_reweighting: topPtReweightWeight
   Z_pt_reweighting: ZPtMassReweightWeight
@@ -105,3 +103,12 @@ wps:
       - Medium
       - Tight
       - VTight
+
+additional_features:
+  - tau_decaymode_1
+  - tau_decaymode_2
+  - mass_1
+  - mass_2
+  - iso_1
+  - iso_2
+  - deltaR_ditaupair

--- a/configs/smhtt_ul/2018/preselection_et.yaml
+++ b/configs/smhtt_ul/2018/preselection_et.yaml
@@ -1,108 +1,109 @@
-# This is an example config containing information for the preselection
-
-ntuple_path: "root://cmsxrootd-kit.gridka.de//store/user/sbrommer/CROWN/ntuples/2018_ul_v4/CROWNRun"
-era: "2018"
-channel: "et"
-tree: "ntuple"
-analysis: "smhtt_ul"
-
-output_path: "/ceph/sbrommer/FFmethod/smhtt_ul/03_2023_v5"
-
+channel: et
+tree: ntuple
+analysis: smhtt_ul
 processes:
-    DYjets:
-        tau_gen_modes:
-            - "J"
-            - "T"
-            - "L"
-        samples:
-            - "DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "DY1JetsToLL_M-50_MatchEWPDG20_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "DY2JetsToLL_M-50_MatchEWPDG20_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "DY3JetsToLL_M-50_MatchEWPDG20_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "DY4JetsToLL_M-50_MatchEWPDG20_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-    diboson:
-        tau_gen_modes:
-            - "J"
-            - "T"
-            - "L"
-        samples:
-            - "ZZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "WW_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "WZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X"
-    ttbar:
-        tau_gen_modes:
-            - "J"
-            - "T"
-            - "L"
-        samples:
-            - "TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "TTToHadronic_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X"
-    Wjets:
-        tau_gen_modes:
-            - "all"
-        samples:
-            - "WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "W1JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "W2JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "W3JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "W4JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-    embedding:
-        tau_gen_modes:
-            - "all"
-        samples:
-            - "TauEmbedding-ElTauFinalState_Run2018A-UL2018"
-            - "TauEmbedding-ElTauFinalState_Run2018B-UL2018"
-            - "TauEmbedding-ElTauFinalState_Run2018C-UL2018"
-            - "TauEmbedding-ElTauFinalState_Run2018D-UL2018"
-    data:
-        tau_gen_modes:
-            - "all"
-        samples:
-            - "EGamma_Run2018A-UL2018"
-            - "EGamma_Run2018B-UL2018"
-            - "EGamma_Run2018C-UL2018"
-            - "EGamma_Run2018D-UL2018"
-    ST:
-        tau_gen_modes:
-            - "J"
-            - "T"
-            - "L"
-        samples:
-            - "ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X"
-
+  DYjets:
+    samples:
+      - DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - DY1JetsToLL_M-50_MatchEWPDG20_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - DY2JetsToLL_M-50_MatchEWPDG20_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - DY3JetsToLL_M-50_MatchEWPDG20_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - DY4JetsToLL_M-50_MatchEWPDG20_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+    tau_gen_modes:
+      - J
+      - T
+      - L
+  ST:
+    samples:
+      - ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X
+    tau_gen_modes:
+      - J
+      - T
+      - L
+  Wjets:
+    samples:
+      - WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - W1JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - W2JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - W3JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - W4JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+    tau_gen_modes:
+      - all
+  data:
+    samples:
+      - EGamma_Run2018A-UL2018
+      - EGamma_Run2018B-UL2018
+      - EGamma_Run2018C-UL2018
+      - EGamma_Run2018D-UL2018
+    tau_gen_modes:
+      - all
+  diboson:
+    samples:
+      - ZZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - WW_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - WZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X
+    tau_gen_modes:
+      - J
+      - T
+      - L
+  embedding:
+    samples:
+      - TauEmbedding-ElTauFinalState_Run2018A-UL2018
+      - TauEmbedding-ElTauFinalState_Run2018B-UL2018
+      - TauEmbedding-ElTauFinalState_Run2018C-UL2018
+      - TauEmbedding-ElTauFinalState_Run2018D-UL2018
+    tau_gen_modes:
+      - all
+  ttbar:
+    samples:
+      - TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - TTToHadronic_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X
+    tau_gen_modes:
+      - J
+      - T
+      - L
 event_selection:
-    lep_pt: "pt_1 > 33"
-    had_tau_pt: "pt_2 > 30"
-    had_tau_eta: "abs(eta_2) < 2.3"
-    had_tau_decay_mode: "(tau_decaymode_2 == 0) || (tau_decaymode_2 == 1) || (tau_decaymode_2 == 10) || (tau_decaymode_2 == 11)"
-    had_tau_id_vs_ele: "id_tau_vsEle_Tight_2 > 0.5"
-    had_tau_id_vs_mu: "id_tau_vsMu_VLoose_2 > 0.5"
-    single_trigger: "(trg_single_ele32 > 0.5) || (trg_single_ele35 > 0.5)"
-
+  had_tau_decay_mode: (tau_decaymode_2 == 0) || (tau_decaymode_2 == 1) || (tau_decaymode_2 == 10) || (tau_decaymode_2 == 11)
+  had_tau_eta: abs(eta_2) < 2.3
+  had_tau_id_vs_ele: id_tau_vsEle_Tight_2 > 0.5
+  had_tau_id_vs_mu: id_tau_vsMu_VLoose_2 > 0.5
+  had_tau_pt: pt_2 > 30
+  lep_pt: pt_1 > 33
+  single_trigger: (trg_single_ele32 > 0.5) || (trg_single_ele35 > 0.5)
 mc_weights:
-    # general weights: string is passed directly as weight
-    pileup: "puweight"
-    lep_iso: "iso_wgt_ele_1"
-    lep_id: "id_wgt_ele_1"
-    had_tau_id_vs_ele: (gen_match_2==5) * ((id_tau_vsEle_Tight_2>0.5)*id_wgt_tau_vsEle_Tight_2 + (id_tau_vsEle_Tight_2<0.5)) + (gen_match_2!=5)
-    had_tau_id_vs_mu: (gen_match_2==5) * ((id_tau_vsMu_VLoose_2>0.5)*id_wgt_tau_vsMu_VLoose_2 + (id_tau_vsMu_VLoose_2<0.5)) + (gen_match_2!=5)
-    single_trigger: "trg_wgt_single_ele32orele35"
-
-    # special weights: these are not generally applied, e.g. only for a specific process or era
-    # here the string is a needed information to apply the weight -> see corresponding functions
-    generator: "stitching"
-    lumi: ""
-    Z_pt_reweighting: "ZPtMassReweightWeight"
-    Top_pt_reweighting: "topPtReweightWeight"
-
+  Top_pt_reweighting: topPtReweightWeight
+  Z_pt_reweighting: ZPtMassReweightWeight
+  generator:
+    stitching:
+      - DYjets
+      - Wjets
+  had_tau_id_vs_ele: (gen_match_2==5) * ((id_tau_vsEle_Tight_2>0.5)*id_wgt_tau_vsEle_Tight_2 + (id_tau_vsEle_Tight_2<0.5)) + (gen_match_2!=5)
+  had_tau_id_vs_mu: (gen_match_2==5) * ((id_tau_vsMu_VLoose_2>0.5)*id_wgt_tau_vsMu_VLoose_2 + (id_tau_vsMu_VLoose_2<0.5)) + (gen_match_2!=5)
+  lep_id: id_wgt_ele_1
+  lep_iso: iso_wgt_ele_1
+  lumi: ""
+  pileup: puweight
+  single_trigger: trg_wgt_single_ele32orele35
 emb_weights:
-    # general weights (for embedding): string is passed directly as weight
-    generator: "emb_genweight * emb_idsel_wgt_1 * emb_idsel_wgt_2 * emb_triggersel_wgt"
-    lep_iso: "iso_wgt_ele_1"
-    lep_id: "id_wgt_ele_1"
-    single_trigger: "trg_wgt_single_ele32orele35"
+  generator: emb_genweight * emb_idsel_wgt_1 * emb_idsel_wgt_2 * emb_triggersel_wgt
+  lep_id: id_wgt_ele_1
+  lep_iso: iso_wgt_ele_1
+  single_trigger: trg_wgt_single_ele32orele35
+wps:
+  tau_vs_jet:
+    wgt:
+      - Medium
+      - Tight
+      - VTight
+    wp:
+      - VVLoose
+      - VLoose
+      - Loose
+      - Medium
+      - Tight
+      - VTight

--- a/configs/smhtt_ul/2018/preselection_et.yaml
+++ b/configs/smhtt_ul/2018/preselection_et.yaml
@@ -1,6 +1,4 @@
 channel: et
-tree: ntuple
-analysis: smhtt_ul
 processes:
   DYjets:
     samples:

--- a/configs/smhtt_ul/2018/preselection_mt.yaml
+++ b/configs/smhtt_ul/2018/preselection_mt.yaml
@@ -67,12 +67,10 @@ processes:
       - L
 event_selection:
   had_tau_decay_mode: (tau_decaymode_2 == 0) || (tau_decaymode_2 == 1) || (tau_decaymode_2 == 10) || (tau_decaymode_2 == 11)
-  had_tau_eta: abs(eta_2) < 2.3
   had_tau_id_vs_ele: id_tau_vsEle_VVLoose_2 > 0.5
   had_tau_id_vs_mu: id_tau_vsMu_Tight_2 > 0.5
   had_tau_pt: pt_2 > 30
-  lep_pt: pt_1 > 25
-  single_trigger: (trg_single_mu24 > 0.5) || (trg_single_mu27 > 0.5)
+  lep_pt: ((pt_1 > 25) && ((trg_single_mu27 > 0.5) || (trg_single_mu24 > 0.5)))
 mc_weights:
   Top_pt_reweighting: topPtReweightWeight
   Z_pt_reweighting: ZPtMassReweightWeight
@@ -105,3 +103,12 @@ wps:
       - Medium
       - Tight
       - VTight
+
+additional_features:
+  - tau_decaymode_1
+  - tau_decaymode_2
+  - mass_1
+  - mass_2
+  - iso_1
+  - iso_2
+  - deltaR_ditaupair

--- a/configs/smhtt_ul/2018/preselection_mt.yaml
+++ b/configs/smhtt_ul/2018/preselection_mt.yaml
@@ -1,6 +1,4 @@
 channel: mt
-tree: ntuple
-analysis: smhtt_ul
 processes:
   DYjets:
     samples:

--- a/configs/smhtt_ul/2018/preselection_mt.yaml
+++ b/configs/smhtt_ul/2018/preselection_mt.yaml
@@ -1,114 +1,109 @@
-# This is an example config containing information for the preselection
-
-ntuple_path: "root://cmsxrootd-kit.gridka.de//store/user/sbrommer/CROWN/ntuples/2018_ul_v4/CROWNRun"
-era: "2018"
-channel: "mt"
-tree: "ntuple"
-analysis: "smhtt_ul"
-
-output_path: "/ceph/sbrommer/FFmethod/smhtt_ul/03_2023_v6"
-
+channel: mt
+tree: ntuple
+analysis: smhtt_ul
 processes:
-    DYjets:
-        tau_gen_modes:
-            - "J"
-            - "T"
-            - "L"
-        samples:
-            - "DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            # - "DYJetsToLL_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            # - "DYJetsToLL_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            # - "DYJetsToLL_2J_TuneCP5_13TeV-amcatnloFXFX-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "DY1JetsToLL_M-50_MatchEWPDG20_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "DY2JetsToLL_M-50_MatchEWPDG20_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "DY3JetsToLL_M-50_MatchEWPDG20_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "DY4JetsToLL_M-50_MatchEWPDG20_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-    diboson:
-        tau_gen_modes:
-            - "J"
-            - "T"
-            - "L"
-        samples:
-            - "ZZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "WW_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "WZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X"
-    ttbar:
-        tau_gen_modes:
-            - "J"
-            - "T"
-            - "L"
-        samples:
-            - "TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "TTToHadronic_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X"
-    Wjets:
-        tau_gen_modes:
-            - "all"
-        samples:
-            - "WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            # - "WJetsToLNu_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            # - "WJetsToLNu_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            # - "WJetsToLNu_2J_TuneCP5_13TeV-amcatnloFXFX-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "W1JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "W2JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "W3JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "W4JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-    embedding:
-        tau_gen_modes:
-            - "all"
-        samples:
-            - "TauEmbedding-MuTauFinalState_Run2018A-UL2018"
-            - "TauEmbedding-MuTauFinalState_Run2018B-UL2018"
-            - "TauEmbedding-MuTauFinalState_Run2018C-UL2018"
-            - "TauEmbedding-MuTauFinalState_Run2018D-UL2018"
-    data:
-        tau_gen_modes:
-            - "all"
-        samples:
-            - "SingleMuon_Run2018A-UL2018"
-            - "SingleMuon_Run2018B-UL2018"
-            - "SingleMuon_Run2018C-UL2018"
-            - "SingleMuon_Run2018D-UL2018"
-    ST:
-        tau_gen_modes:
-            - "J"
-            - "T"
-            - "L"
-        samples:
-            - "ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X"
-
+  DYjets:
+    samples:
+      - DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - DY1JetsToLL_M-50_MatchEWPDG20_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - DY2JetsToLL_M-50_MatchEWPDG20_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - DY3JetsToLL_M-50_MatchEWPDG20_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - DY4JetsToLL_M-50_MatchEWPDG20_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+    tau_gen_modes:
+      - J
+      - T
+      - L
+  ST:
+    samples:
+      - ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X
+    tau_gen_modes:
+      - J
+      - T
+      - L
+  Wjets:
+    samples:
+      - WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - W1JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - W2JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - W3JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - W4JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+    tau_gen_modes:
+      - all
+  data:
+    samples:
+      - SingleMuon_Run2018A-UL2018
+      - SingleMuon_Run2018B-UL2018
+      - SingleMuon_Run2018C-UL2018
+      - SingleMuon_Run2018D-UL2018
+    tau_gen_modes:
+      - all
+  diboson:
+    samples:
+      - ZZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - WW_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - WZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X
+    tau_gen_modes:
+      - J
+      - T
+      - L
+  embedding:
+    samples:
+      - TauEmbedding-MuTauFinalState_Run2018A-UL2018
+      - TauEmbedding-MuTauFinalState_Run2018B-UL2018
+      - TauEmbedding-MuTauFinalState_Run2018C-UL2018
+      - TauEmbedding-MuTauFinalState_Run2018D-UL2018
+    tau_gen_modes:
+      - all
+  ttbar:
+    samples:
+      - TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - TTToHadronic_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X
+    tau_gen_modes:
+      - J
+      - T
+      - L
 event_selection:
-    lep_pt: "pt_1 > 25"
-    had_tau_pt: "pt_2 > 30"
-    had_tau_eta: "abs(eta_2) < 2.3"
-    had_tau_decay_mode: "(tau_decaymode_2 == 0) || (tau_decaymode_2 == 1) || (tau_decaymode_2 == 10) || (tau_decaymode_2 == 11)"
-    had_tau_id_vs_ele: "id_tau_vsEle_VVLoose_2 > 0.5"
-    had_tau_id_vs_mu: "id_tau_vsMu_Tight_2 > 0.5"
-    single_trigger: "(trg_single_mu24 > 0.5) || (trg_single_mu27 > 0.5)"
-
+  had_tau_decay_mode: (tau_decaymode_2 == 0) || (tau_decaymode_2 == 1) || (tau_decaymode_2 == 10) || (tau_decaymode_2 == 11)
+  had_tau_eta: abs(eta_2) < 2.3
+  had_tau_id_vs_ele: id_tau_vsEle_VVLoose_2 > 0.5
+  had_tau_id_vs_mu: id_tau_vsMu_Tight_2 > 0.5
+  had_tau_pt: pt_2 > 30
+  lep_pt: pt_1 > 25
+  single_trigger: (trg_single_mu24 > 0.5) || (trg_single_mu27 > 0.5)
 mc_weights:
-    # general weights: string is passed directly as weight
-    pileup: "puweight"
-    lep_iso: "iso_wgt_mu_1"
-    lep_id: "id_wgt_mu_1"
-    had_tau_id_vs_ele: (gen_match_2==5) * ((id_tau_vsEle_VVLoose_2>0.5)*id_wgt_tau_vsEle_VVLoose_2 + (id_tau_vsEle_VVLoose_2<0.5)) + (gen_match_2!=5)
-    had_tau_id_vs_mu: (gen_match_2==5) * ((id_tau_vsMu_Tight_2>0.5)*id_wgt_tau_vsMu_Tight_2 + (id_tau_vsMu_Tight_2<0.5)) + (gen_match_2!=5)
-    single_trigger: "trg_wgt_single_mu24ormu27"
-    
-    # special weights: these are not generally applied, e.g. only for a specific process or era
-    # here the string is a needed information to apply the weight -> see corresponding functions
-    generator: "stitching"
-    lumi: ""
-    Z_pt_reweighting: "ZPtMassReweightWeight"
-    Top_pt_reweighting: "topPtReweightWeight"
-
+  Top_pt_reweighting: topPtReweightWeight
+  Z_pt_reweighting: ZPtMassReweightWeight
+  generator:
+    stitching:
+      - DYjets
+      - Wjets
+  had_tau_id_vs_ele: (gen_match_2==5) * ((id_tau_vsEle_VVLoose_2>0.5)*id_wgt_tau_vsEle_VVLoose_2 + (id_tau_vsEle_VVLoose_2<0.5)) + (gen_match_2!=5)
+  had_tau_id_vs_mu: (gen_match_2==5) * ((id_tau_vsMu_Tight_2>0.5)*id_wgt_tau_vsMu_Tight_2 + (id_tau_vsMu_Tight_2<0.5)) + (gen_match_2!=5)
+  lep_id: id_wgt_mu_1
+  lep_iso: iso_wgt_mu_1
+  lumi: ""
+  pileup: puweight
+  single_trigger: trg_wgt_single_mu24ormu27
 emb_weights:
-    # general weights (for embedding): string is passed directly as weight
-    generator: "emb_genweight * emb_idsel_wgt_1 * emb_idsel_wgt_2 * emb_triggersel_wgt"
-    lep_iso: "iso_wgt_mu_1"
-    lep_id: "id_wgt_mu_1"
-    single_trigger: "trg_wgt_single_mu24ormu27"
+  generator: emb_genweight * emb_idsel_wgt_1 * emb_idsel_wgt_2 * emb_triggersel_wgt
+  lep_id: id_wgt_mu_1
+  lep_iso: iso_wgt_mu_1
+  single_trigger: trg_wgt_single_mu24ormu27
+wps:
+  tau_vs_jet:
+    wgt:
+      - Medium
+      - Tight
+      - VTight
+    wp:
+      - VVLoose
+      - VLoose
+      - Loose
+      - Medium
+      - Tight
+      - VTight

--- a/configs/smhtt_ul/2018/preselection_tt.yaml
+++ b/configs/smhtt_ul/2018/preselection_tt.yaml
@@ -1,92 +1,98 @@
-# This is an example config containing information for the preselection
-
-ntuple_path: "root://cmsxrootd-kit.gridka.de//store/user/sbrommer/CROWN/ntuples/tautau_2018_v4/CROWNRun"
-era: "2018"
-channel: "tt"
-tree: "ntuple"
-analysis: "smhtt_ul"
-
-output_path: "/ceph/sbrommer/FFmethod/smhtt_ul/03_2023_v2"
-
+channel: tt
+tree: ntuple
+analysis: smhtt_ul
 processes:
-    DYjets:
-        tau_gen_modes:
-            - "J"
-            - "T"
-            - "L"
-        samples:
-            - "DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-    diboson:
-        tau_gen_modes:
-            - "J"
-            - "T"
-            - "L"
-        samples:
-            # - WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X
-            - WW_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X
-            # - WZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8_RunIISummer20UL18NanoAODv9-106X
-            # - WZTo3LNu_TuneCP5_13TeV-amcatnloFXFX-pythia8_RunIISummer20UL18NanoAODv9-106X
-            - WZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X
-            # - ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8_RunIISummer20UL18NanoAODv9-106X
-            # - ZZTo4L_TuneCP5_13TeV_powheg_pythia8_RunIISummer20UL18NanoAODv9-106X
-            - ZZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X
-    ttbar:
-        tau_gen_modes:
-            - "J"
-            - "T"
-            - "L"
-        samples:
-            - "TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "TTToHadronic_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X"
-            - "TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X"
-    Wjets:
-        tau_gen_modes:
-            - "all"
-        samples:
-            - "WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X"
-    embedding:
-        tau_gen_modes:
-            - "all"
-        samples:
-            - "TauEmbedding-TauTauFinalState_Run2018A-UL2018"
-            - "TauEmbedding-TauTauFinalState_Run2018B-UL2018"
-            - "TauEmbedding-TauTauFinalState_Run2018C-UL2018"
-            - "TauEmbedding-TauTauFinalState_Run2018D-UL2018"
-    data:
-        tau_gen_modes:
-            - "all"
-        samples:
-            - "Tau_Run2018A-UL2018"
-            - "Tau_Run2018B-UL2018"
-            - "Tau_Run2018C-UL2018"
-            - "Tau_Run2018D-UL2018"
-
+  DYjets:
+    samples:
+      - DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+    tau_gen_modes:
+      - J
+      - T
+      - L
+  ST:
+    samples:
+      - ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X
+    tau_gen_modes:
+      - J
+      - T
+      - L
+  Wjets:
+    samples:
+      - WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8_RunIISummer20UL18NanoAODv9-106X
+    tau_gen_modes:
+      - all
+  data:
+    samples:
+      - Tau_Run2018A-UL2018
+      - Tau_Run2018B-UL2018
+      - Tau_Run2018C-UL2018
+      - Tau_Run2018D-UL2018
+    tau_gen_modes:
+      - all
+  diboson:
+    samples:
+      - WW_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - WZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - ZZ_TuneCP5_13TeV-pythia8_RunIISummer20UL18NanoAODv9-106X
+    tau_gen_modes:
+      - J
+      - T
+      - L
+  embedding:
+    samples:
+      - TauEmbedding-TauTauFinalState_Run2018A-UL2018
+      - TauEmbedding-TauTauFinalState_Run2018B-UL2018
+      - TauEmbedding-TauTauFinalState_Run2018C-UL2018
+      - TauEmbedding-TauTauFinalState_Run2018D-UL2018
+    tau_gen_modes:
+      - all
+  ttbar:
+    samples:
+      - TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - TTToHadronic_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X
+      - TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8_RunIISummer20UL18NanoAODv9-106X
+    tau_gen_modes:
+      - J
+      - T
+      - L
 event_selection:
-    had_tau_pt: "(pt_1 > 40) && (pt_2 > 40)"
-    had_tau_eta: "(abs(eta_1) < 2.3) && (abs(eta_2) < 2.3)"
-    had_tau_decay_mode_1: "(tau_decaymode_1 == 0) || (tau_decaymode_1 == 1) || (tau_decaymode_1 == 10) || (tau_decaymode_1 == 11)"
-    had_tau_decay_mode_2: "(tau_decaymode_2 == 0) || (tau_decaymode_2 == 1) || (tau_decaymode_2 == 10) || (tau_decaymode_2 == 11)"
-    had_tau_id_vs_ele: "(id_tau_vsEle_VVLoose_1 > 0.5) && (id_tau_vsEle_VVLoose_2 > 0.5)"
-    had_tau_id_vs_mu: "(id_tau_vsMu_VLoose_1 > 0.5) && (id_tau_vsMu_VLoose_2 > 0.5)"
-    double_trigger: "(trg_double_tau35_tightiso_tightid > 0.5) || (trg_double_tau35_mediumiso_hps > 0.5) || (trg_double_tau40_mediumiso_tightid > 0.5) || (trg_double_tau40_tightiso > 0.5)"
-
+  double_trigger: (trg_double_tau35_tightiso_tightid > 0.5) || (trg_double_tau35_mediumiso_hps > 0.5) || (trg_double_tau40_mediumiso_tightid > 0.5) || (trg_double_tau40_tightiso > 0.5)
+  had_tau_decay_mode_1: (tau_decaymode_1 == 0) || (tau_decaymode_1 == 1) || (tau_decaymode_1 == 10) || (tau_decaymode_1 == 11)
+  had_tau_decay_mode_2: (tau_decaymode_2 == 0) || (tau_decaymode_2 == 1) || (tau_decaymode_2 == 10) || (tau_decaymode_2 == 11)
+  had_tau_eta: (abs(eta_1) < 2.3) && (abs(eta_2) < 2.3)
+  had_tau_id_vs_ele: (id_tau_vsEle_VVLoose_1 > 0.5) && (id_tau_vsEle_VVLoose_2 > 0.5)
+  had_tau_id_vs_mu: (id_tau_vsMu_VLoose_1 > 0.5) && (id_tau_vsMu_VLoose_2 > 0.5)
+  had_tau_pt: (pt_1 > 40) && (pt_2 > 40)
 mc_weights:
-    # general weights: string is passed directly as weight
-    pileup: "puweight"
-    had_tau_id_vs_ele_1: (gen_match_1==5) * ((id_tau_vsEle_VVLoose_1>0.5)*id_wgt_tau_vsEle_VVLoose_1 + (id_tau_vsEle_VVLoose_1<0.5)) + (gen_match_1!=5)
-    had_tau_id_vs_ele_2: (gen_match_2==5) * ((id_tau_vsEle_VVLoose_2>0.5)*id_wgt_tau_vsEle_VVLoose_2 + (id_tau_vsEle_VVLoose_2<0.5)) + (gen_match_2!=5)
-    had_tau_id_vs_mu_1: (gen_match_1==5) * ((id_tau_vsMu_VLoose_1>0.5)*id_wgt_tau_vsMu_VLoose_1 + (id_tau_vsMu_VLoose_1<0.5)) + (gen_match_1!=5)
-    had_tau_id_vs_mu_2: (gen_match_2==5) * ((id_tau_vsMu_VLoose_2>0.5)*id_wgt_tau_vsMu_VLoose_2 + (id_tau_vsMu_VLoose_2<0.5)) + (gen_match_2!=5)
-
-    # special weights: these are not generally applied, e.g. only for a specific process or era
-    # here the string is a needed information to apply the weight -> see corresponding functions
-    generator: "stitching"
-    lumi: ""
-    Z_pt_reweighting: "ZPtMassReweightWeight"
-    Top_pt_reweighting: "topPtReweightWeight"
-
+  Top_pt_reweighting: topPtReweightWeight
+  Z_pt_reweighting: ZPtMassReweightWeight
+  generator:
+    stitching:
+      - DYjets
+      - Wjets
+  had_tau_id_vs_ele_1: (gen_match_1==5) * ((id_tau_vsEle_VVLoose_1>0.5)*id_wgt_tau_vsEle_VVLoose_1 + (id_tau_vsEle_VVLoose_1<0.5)) + (gen_match_1!=5)
+  had_tau_id_vs_ele_2: (gen_match_2==5) * ((id_tau_vsEle_VVLoose_2>0.5)*id_wgt_tau_vsEle_VVLoose_2 + (id_tau_vsEle_VVLoose_2<0.5)) + (gen_match_2!=5)
+  had_tau_id_vs_mu_1: (gen_match_1==5) * ((id_tau_vsMu_VLoose_1>0.5)*id_wgt_tau_vsMu_VLoose_1 + (id_tau_vsMu_VLoose_1<0.5)) + (gen_match_1!=5)
+  had_tau_id_vs_mu_2: (gen_match_2==5) * ((id_tau_vsMu_VLoose_2>0.5)*id_wgt_tau_vsMu_VLoose_2 + (id_tau_vsMu_VLoose_2<0.5)) + (gen_match_2!=5)
+  lumi: ""
+  pileup: puweight
 emb_weights:
-    # general weights (for embedding): string is passed directly as weight
-    generator: "emb_genweight * emb_idsel_wgt_1 * emb_idsel_wgt_2 * emb_triggersel_wgt"
-    double_trigger: "emb_trg_wgt_1 * emb_trg_wgt_2"
+  double_trigger: emb_trg_wgt_1 * emb_trg_wgt_2
+  generator: emb_genweight * emb_idsel_wgt_1 * emb_idsel_wgt_2 * emb_triggersel_wgt
+wps:
+  tau_vs_jet:
+    wgt:
+      - Medium
+      - Tight
+      - VTight
+    wp:
+      - VVLoose
+      - VLoose
+      - Loose
+      - Medium
+      - Tight
+      - VTight

--- a/configs/smhtt_ul/2018/preselection_tt.yaml
+++ b/configs/smhtt_ul/2018/preselection_tt.yaml
@@ -1,6 +1,4 @@
 channel: tt
-tree: ntuple
-analysis: smhtt_ul
 processes:
   DYjets:
     samples:

--- a/configs/smhtt_ul/2018/preselection_tt.yaml
+++ b/configs/smhtt_ul/2018/preselection_tt.yaml
@@ -58,13 +58,12 @@ processes:
       - T
       - L
 event_selection:
-  double_trigger: (trg_double_tau35_tightiso_tightid > 0.5) || (trg_double_tau35_mediumiso_hps > 0.5) || (trg_double_tau40_mediumiso_tightid > 0.5) || (trg_double_tau40_tightiso > 0.5)
   had_tau_decay_mode_1: (tau_decaymode_1 == 0) || (tau_decaymode_1 == 1) || (tau_decaymode_1 == 10) || (tau_decaymode_1 == 11)
   had_tau_decay_mode_2: (tau_decaymode_2 == 0) || (tau_decaymode_2 == 1) || (tau_decaymode_2 == 10) || (tau_decaymode_2 == 11)
-  had_tau_eta: (abs(eta_1) < 2.3) && (abs(eta_2) < 2.3)
   had_tau_id_vs_ele: (id_tau_vsEle_VVLoose_1 > 0.5) && (id_tau_vsEle_VVLoose_2 > 0.5)
   had_tau_id_vs_mu: (id_tau_vsMu_VLoose_1 > 0.5) && (id_tau_vsMu_VLoose_2 > 0.5)
   had_tau_pt: (pt_1 > 40) && (pt_2 > 40)
+  double_trigger: (trg_double_tau35_tightiso_tightid > 0.5) || (trg_double_tau35_mediumiso_hps > 0.5) || (trg_double_tau40_mediumiso_tightid > 0.5) || (trg_double_tau40_tightiso > 0.5)
 mc_weights:
   Top_pt_reweighting: topPtReweightWeight
   Z_pt_reweighting: ZPtMassReweightWeight
@@ -94,3 +93,12 @@ wps:
       - Medium
       - Tight
       - VTight
+
+additional_features:
+  - tau_decaymode_1
+  - tau_decaymode_2
+  - mass_1
+  - mass_2
+  - iso_1
+  - iso_2
+  - deltaR_ditaupair

--- a/ff_calculation.py
+++ b/ff_calculation.py
@@ -47,6 +47,7 @@ def run_ff_calculation(
         Depending on the "process" either a dictionary with fake factor function expressions or a dictionary with process fraction values
     """
     process, config, sample_paths, output_path = args
+    config = defaultdict(lambda: None, config)
     log = logging.getLogger(f"ff_calculation.{process}")
 
     if process in ["QCD", "QCD_subleading"]:

--- a/ff_calculation.py
+++ b/ff_calculation.py
@@ -47,7 +47,6 @@ def run_ff_calculation(
         Depending on the "process" either a dictionary with fake factor function expressions or a dictionary with process fraction values
     """
     process, config, sample_paths, output_path = args
-    config = defaultdict(lambda: None, config)
     log = logging.getLogger(f"ff_calculation.{process}")
 
     if process in ["QCD", "QCD_subleading"]:

--- a/ff_calculation.py
+++ b/ff_calculation.py
@@ -49,49 +49,27 @@ def run_ff_calculation(
     process, config, sample_paths, output_path = args
     log = logging.getLogger(f"ff_calculation.{process}")
 
-    if process in ["QCD", "QCD_subleading"]:
+    ff_calculation_functions = {
+        "QCD": FF_QCD.calculation_QCD_FFs,
+        "QCD_subleading": FF_QCD.calculation_QCD_FFs,
+        "Wjets": FF_Wjets.calculation_Wjets_FFs,
+        "ttbar": FF_ttbar.calculation_ttbar_FFs,
+        "ttbar_subleading": FF_ttbar.calculation_ttbar_FFs,
+        "process_fractions": fraction_calculation,
+        "process_fractions_subleading": fraction_calculation
+    }
+    try:
         log.info(f"Calculating fake factors for the {process} process.")
         log.info("-" * 50)
-        result = FF_QCD.calculation_QCD_FFs(
+        return ff_calculation_functions[process](
             config=config,
             sample_paths=sample_paths,
             output_path=output_path,
             process=process,
             logger=f"ff_calculation.{process}",
         )
-    elif process == "Wjets":
-        log.info("Calculating fake factors for the Wjets process.")
-        log.info("-" * 50)
-        result = FF_Wjets.calculation_Wjets_FFs(
-            config=config,
-            sample_paths=sample_paths,
-            output_path=output_path,
-            logger=f"ff_calculation.{process}",
-        )
-    elif process in ["ttbar", "ttbar_subleading"]:
-        log.info(f"Calculating fake factors for the {process} process.")
-        log.info("-" * 50)
-        result = FF_ttbar.calculation_ttbar_FFs(
-            config=config,
-            sample_paths=sample_paths,
-            output_path=output_path,
-            process=process,
-            logger=f"ff_calculation.{process}",
-        )
-    elif process in ["process_fractions", "process_fractions_subleading"]:
-        log.info(f"Calculating the process {process} for the FF application.")
-        log.info("-" * 50)
-        result = fraction_calculation(
-            config=config,
-            sample_paths=sample_paths,
-            output_path=output_path,
-            process=process,
-            logger=f"ff_calculation.{process}",
-        )
-    else:
+    except KeyError:
         raise Exception(f"Target process: Such a process is not known: {process}")
-
-    return result
 
 
 if __name__ == "__main__":

--- a/ff_corrections.py
+++ b/ff_corrections.py
@@ -75,45 +75,24 @@ def run_ff_calculation_for_DRtoSR(
             to_AR_SR=False,
         )
 
-        if process == "QCD":
-            log.info(
-                "Calculating fake factors for the SR-DR correction for the QCD process."
-            )
+        ff_calculation_function = {
+            "QCD": FF_QCD.calculation_QCD_FFs,
+            "QCD_subleading": FF_QCD.calculation_QCD_FFs,
+            "Wjets": FF_Wjets.calculation_Wjets_FFs,
+        }
+        result = None
+        try:
+            log.info(f"Calculating fake factors for the SR-DR correction for the {process} process.")
             log.info("-" * 50)
-            result = FF_QCD.calculation_QCD_FFs(
+            result = ff_calculation_function[process](
                 config=temp_conf,
                 sample_paths=sample_paths,
                 output_path=output_path,
                 process=process,
                 logger=f"ff_corrections.{process}",
             )
-        elif process == "QCD_subleading":
-            log.info(
-                "Calculating fake factors for the SR-DR correction for the QCD(subleading) process."
-            )
-            log.info("-" * 50)
-            result = FF_QCD.calculation_QCD_FFs(
-                config=temp_conf,
-                sample_paths=sample_paths,
-                output_path=output_path,
-                process=process,
-                logger=f"ff_corrections.{process}",
-            )
-        elif process == "Wjets":
-            log.info(
-                "Calculating fake factors for the SR-DR correction for the Wjets process."
-            )
-            log.info("-" * 50)
-            result = FF_Wjets.calculation_Wjets_FFs(
-                config=temp_conf,
-                sample_paths=sample_paths,
-                output_path=output_path,
-                logger=f"ff_corrections.{process}",
-            )
-        else:
-            log.info(f"No DR to SR calculation function is defined for {process}.")
-            result = None
-
+        except KeyError:
+            raise ValueError(f"Process {process} not known!")
     else:
         log.info(f"Target process {process} has no DR to SR calculation defined.")
         result = None
@@ -172,12 +151,19 @@ def run_non_closure_for_DRtoSR(
             to_AR_SR=False,
         )
 
-        if process == "QCD":
+        _rename_me = {
+            "QCD": FF_QCD.non_closure_correction,
+            "QCD_subleading": FF_QCD.non_closure_correction,
+            "Wjets": FF_Wjets.non_closure_correction,
+        }
+
+        result = None
+        try:
             log.info(
-                f"Calculating closure correction for the DR to SR correction of the QCD process dependent on {closure_correction}."
+                f"Calculating closure correction for the DR to SR correction of the {process} process dependent on {closure_correction}."
             )
             log.info("-" * 50)
-            result = FF_QCD.non_closure_correction(
+            result = _rename_me[process](
                 config=temp_conf,
                 corr_config=corr_config,
                 sample_paths=sample_paths,
@@ -189,47 +175,8 @@ def run_non_closure_for_DRtoSR(
                 for_DRtoSR=True,
                 logger=f"ff_corrections.{process}",
             )
-
-        elif process == "QCD_subleading":
-            log.info(
-                f"Calculating closure correction for the DR to SR correction of the QCD(subleading) process dependent on {closure_correction}."
-            )
-            log.info("-" * 50)
-            result = FF_QCD.non_closure_correction(
-                config=temp_conf,
-                corr_config=corr_config,
-                sample_paths=sample_paths,
-                output_path=output_path,
-                process=process,
-                closure_variable=closure_correction,
-                evaluator=evaluator,
-                corr_evaluator=None,
-                for_DRtoSR=True,
-                logger=f"ff_corrections.{process}",
-            )
-
-        elif process == "Wjets":
-            log.info(
-                f"Calculating closure correction for the DR to SR correction of the Wjets process dependent on {closure_correction}."
-            )
-            log.info("-" * 50)
-            result = FF_Wjets.non_closure_correction(
-                config=temp_conf,
-                corr_config=corr_config,
-                sample_paths=sample_paths,
-                output_path=output_path,
-                closure_variable=closure_correction,
-                evaluator=evaluator,
-                corr_evaluator=None,
-                for_DRtoSR=True,
-                logger=f"ff_corrections.{process}",
-            )
-        else:
-            log.info(
-                f"No closure correction function for DR to SR calculation is defined for {process}."
-            )
-            result = None
-
+        except KeyError:
+            raise ValueError(f"Process {process} not known!")
     else:
         log.info(
             f"Target process {process} has no closure correction for DR to SR calculation defined."

--- a/ff_corrections.py
+++ b/ff_corrections.py
@@ -393,8 +393,15 @@ if __name__ == "__main__":
                             logger=f"ff_corrections.{process}",
                         )
 
-                    if process in ["QCD", "QCD_subleading"]:
-                        corr = FF_QCD.non_closure_correction(
+                    non_closure_correction_functions = {
+                        "QCD": FF_QCD.non_closure_correction,
+                        "QCD_subleading": FF_QCD.non_closure_correction,
+                        "Wjets": FF_Wjets.non_closure_correction,
+                        "ttbar": FF_ttbar.non_closure_correction,
+                        "ttbar_subleading": FF_ttbar.non_closure_correction,
+                    }
+                    try:
+                        corr = non_closure_correction_functions[process](
                             config=temp_conf,
                             corr_config=corr_config,
                             sample_paths=sample_paths,
@@ -406,31 +413,7 @@ if __name__ == "__main__":
                             for_DRtoSR=False,
                             logger=f"ff_corrections.{process}",
                         )
-                    elif process == "Wjets":
-                        corr = FF_Wjets.non_closure_correction(
-                            config=temp_conf,
-                            corr_config=corr_config,
-                            sample_paths=sample_paths,
-                            output_path=save_path_plots,
-                            closure_variable=closure_corr,
-                            evaluator=evaluator,
-                            corr_evaluator=corr_evaluator,
-                            for_DRtoSR=False,
-                            logger=f"ff_corrections.{process}",
-                        )
-                    elif process in ["ttbar", "ttbar_subleading"]:
-                        corr = FF_ttbar.non_closure_correction(
-                            config=temp_conf,
-                            corr_config=corr_config,
-                            sample_paths=sample_paths,
-                            output_path=save_path_plots,
-                            process=process,
-                            closure_variable=closure_corr,
-                            evaluator=evaluator,
-                            corr_evaluator=corr_evaluator,
-                            logger=f"ff_corrections.{process}",
-                        )
-                    else:
+                    except KeyError:
                         raise ValueError(f"Process {process} not known!")
 
                     corrections[process]["non_closure_" + closure_corr] = corr

--- a/ff_corrections.py
+++ b/ff_corrections.py
@@ -34,14 +34,14 @@ parser.add_argument(
     """,
 )
 parser.add_argument(
-    "--only-main-corrections",
-    action="store_true",
-    help="Using this argument means to skip the calculation of the fake factors and corrections for the DR to SR correction and directly calculate the main corrections. This is useful if you already calculated the needed additional fake factors.",
-)
-parser.add_argument(
     "--skip-DRtoSR-ffs",
     action="store_true",
     help="Using this argument means to skip the calculation of the fake factors for the DR to SR correction and directly calculate the corrections. This is useful if you already calculated the needed additional fake factors.",
+)
+parser.add_argument(
+    "--only-main-corrections",
+    action="store_true",
+    help="Using this argument means to skip the calculation of the fake factors and corrections for the DR to SR correction and directly calculate the main corrections. This is useful if you already calculated the needed additional fake factors.",
 )
 
 
@@ -161,7 +161,7 @@ def run_non_closure_for_DRtoSR(
             process=process,
             to_AR_SR=False,
         )
-        
+
         closure_correction = list(
             corr_config["target_processes"][process]["DR_SR"]["non_closure"]
         )[0]

--- a/helper/correctionlib_json.py
+++ b/helper/correctionlib_json.py
@@ -41,7 +41,10 @@ def get_edges_and_content(
 
 
 def write_json(path: str, item: Union[cs.CorrectionSet, cs.Correction]) -> None:
-    with open(path, "w" if not path.endswith(".gz") else "wt") as fout:
+    with (gzip.open if path.endswith(".gz") else open)(
+        path,
+        "w" if not path.endswith(".gz") else "wt",
+    ) as fout:
         fout.write(json.dumps(item.model_dump(exclude_unset=True), indent=4))
 
 

--- a/helper/correctionlib_json.py
+++ b/helper/correctionlib_json.py
@@ -14,16 +14,17 @@ def get_edges_and_content(
     item: Union[str, Any],
     variable_info: Tuple[str, list],
 ):
+    # import ipdb; ipdb.set_trace()
     if isinstance(item, str):
         return {
             "edges": [
-                min(variable_info[1]) - 1,
+                # min(variable_info[1]) - 1,
                 min(variable_info[1]),
                 max(variable_info[1]),
-                max(variable_info[1]) + 1,
+                # max(variable_info[1]) + 1,
             ],
             "content": [
-                eval(item.replace("x", str(min(variable_info[1])))),
+                # eval(item.replace("x", str(min(variable_info[1])))),
                 cs.Formula(
                     nodetype="formula",
                     variables=[gd.variable_translator[variable_info[0]]],
@@ -31,7 +32,7 @@ def get_edges_and_content(
                     expression=item,
                     parameters=None,
                 ),
-                eval(item.replace("x", str(max(variable_info[1])))),
+                # eval(item.replace("x", str(max(variable_info[1])))),
             ],
         }
     return {
@@ -379,7 +380,7 @@ def make_1D_fractions(
         fraction_conf: A dictionary with all the relevant information for the fraction calculation
         variable_info: Tuple with information (name and binning) about the variable the fractions depends on
         fractions: Dictionary of fraction values, e.g. fractions[CATEGORY][VARIATION][PROCESS]
-        fraction_name: Name of the calculated fraction, relevant if more than one fraction should be added 
+        fraction_name: Name of the calculated fraction, relevant if more than one fraction should be added
         uncertainties: Dictionary of uncertainty names which should be added
 
     Return:

--- a/helper/correctionlib_json.py
+++ b/helper/correctionlib_json.py
@@ -10,33 +10,34 @@ import rich
 import configs.general_definitions as gd
 
 
-def get_edges(variable_info: Tuple[str, list]) -> List[Union[float, int]]:
-    return [
-        min(variable_info[1]) - 1,
-        min(variable_info[1]),
-        max(variable_info[1]),
-        max(variable_info[1]) + 1,
-    ]
-
-
-def get_ff_content(
+def get_edges_and_content(
     item: Union[str, Any],
-    variable_info
-) -> List:
+    variable_info: Tuple[str, list],
+):
     if isinstance(item, str):
-        return [
-            eval(item.replace("x", str(min(variable_info[1])))),
-            cs.Formula(
-                nodetype="formula",
-                variables=[gd.variable_translator[variable_info[0]]],
-                parser="TFormula",
-                expression=item,
-                parameters=None,
-            ),
-            eval(item.replace("x", str(max(variable_info[1])))),
-        ]
-    else:
-        raise NotImplementedError("Non string items are not supported yet.")
+        return {
+            "edges": [
+                min(variable_info[1]) - 1,
+                min(variable_info[1]),
+                max(variable_info[1]),
+                max(variable_info[1]) + 1,
+            ],
+            "content": [
+                eval(item.replace("x", str(min(variable_info[1])))),
+                cs.Formula(
+                    nodetype="formula",
+                    variables=[gd.variable_translator[variable_info[0]]],
+                    parser="TFormula",
+                    expression=item,
+                    parameters=None,
+                ),
+                eval(item.replace("x", str(max(variable_info[1])))),
+            ],
+        }
+    return {
+        "edges": variable_info[1],
+        "content": item,
+    }
 
 
 def write_json(path: str, item: Union[cs.CorrectionSet, cs.Correction]) -> None:
@@ -206,8 +207,7 @@ def make_1D_ff(
                             cs.Binning(
                                 nodetype="binning",
                                 input=gd.variable_translator[variable_info[0]],
-                                edges=get_edges(variable_info),
-                                content=get_ff_content(ff_functions[cat1][unc], variable_info),
+                                **get_edges_and_content(ff_functions[cat1][unc], variable_info),
                                 flow="clamp",
                             )
                             for cat1 in ff_functions
@@ -225,8 +225,7 @@ def make_1D_ff(
                     cs.Binning(
                         nodetype="binning",
                         input=gd.variable_translator[variable_info[0]],
-                        edges=get_edges(variable_info),
-                        content=get_ff_content(ff_functions[cat1]["nominal"], variable_info),
+                        **get_edges_and_content(ff_functions[cat1]["nominal"], variable_info),
                         flow="clamp",
                     )
                     for cat1 in ff_functions
@@ -318,8 +317,7 @@ def make_2D_ff(
                                     cs.Binning(
                                         nodetype="binning",
                                         input=gd.variable_translator[variable_info[0]],
-                                        edges=get_edges(variable_info),
-                                        content=get_ff_content(ff_functions[cat1][cat2][unc], variable_info),
+                                        **get_edges_and_content(ff_functions[cat1][cat2][unc], variable_info),
                                         flow="clamp",
                                     )
                                     for cat2 in ff_functions[cat1]
@@ -346,8 +344,7 @@ def make_2D_ff(
                             cs.Binning(
                                 nodetype="binning",
                                 input=gd.variable_translator[variable_info[0]],
-                                edges=get_edges(variable_info),
-                                content=get_ff_content(ff_functions[cat1][cat2]["nominal"], variable_info),
+                                **get_edges_and_content(ff_functions[cat1][cat2]["nominal"], variable_info),
                                 flow="clamp",
                             )
                             for cat2 in ff_functions[cat1]

--- a/helper/correctionlib_json.py
+++ b/helper/correctionlib_json.py
@@ -9,6 +9,14 @@ from typing import List, Dict, Union, Tuple
 import configs.general_definitions as gd
 
 
+def get_edges(variable_info: Tuple[str, list]) -> List[Union[float, int]]:
+    return [
+        min(variable_info[1]) - 1,
+        min(variable_info[1]),
+        max(variable_info[1]),
+        max(variable_info[1]) + 1,
+    ]
+
 def generate_ff_corrlib_json(
     config: Dict[str, Union[str, Dict, List]],
     ff_functions: Dict[
@@ -72,7 +80,7 @@ def generate_ff_corrlib_json(
             uncertainties=frac_unc,
         )
         corrlib_corrections.append(fraction)
-    
+
     if "process_fractions_subleading" in config and fractions_subleading is not None:
         var = config["process_fractions_subleading"]["var_dependence"]
         binning = config["process_fractions_subleading"]["var_bins"]
@@ -195,12 +203,7 @@ def make_1D_ff(
                             cs.Binning(
                                 nodetype="binning",
                                 input=gd.variable_translator[variable_info[0]],
-                                edges=[
-                                    0,
-                                    min(variable_info[1]),
-                                    max(variable_info[1]),
-                                    (max(variable_info[1]) + 1),
-                                ],
+                                edges=get_edges(variable_info),
                                 content=[
                                     eval(
                                         ff_functions[cat1][unc].replace(
@@ -239,12 +242,7 @@ def make_1D_ff(
                     cs.Binning(
                         nodetype="binning",
                         input=gd.variable_translator[variable_info[0]],
-                        edges=[
-                            0,
-                            min(variable_info[1]),
-                            max(variable_info[1]),
-                            (max(variable_info[1]) + 1),
-                        ],
+                        edges=get_edges(variable_info),
                         content=[
                             eval(
                                 ff_functions[cat1]["nominal"].replace(
@@ -359,12 +357,7 @@ def make_2D_ff(
                                     cs.Binning(
                                         nodetype="binning",
                                         input=gd.variable_translator[variable_info[0]],
-                                        edges=[
-                                            0,
-                                            min(variable_info[1]),
-                                            max(variable_info[1]),
-                                            (max(variable_info[1]) + 1),
-                                        ],
+                                        edges=get_edges(variable_info),
                                         content=[
                                             eval(
                                                 ff_functions[cat1][cat2][unc].replace(
@@ -416,12 +409,7 @@ def make_2D_ff(
                             cs.Binning(
                                 nodetype="binning",
                                 input=gd.variable_translator[variable_info[0]],
-                                edges=[
-                                    0,
-                                    min(variable_info[1]),
-                                    max(variable_info[1]),
-                                    (max(variable_info[1]) + 1),
-                                ],
+                                edges=get_edges(variable_info),
                                 content=[
                                     eval(
                                         ff_functions[cat1][cat2]["nominal"].replace(

--- a/helper/ff_evaluators.py
+++ b/helper/ff_evaluators.py
@@ -1,8 +1,9 @@
-import os
-import ROOT
-import correctionlib
 import logging
-from typing import Dict, Union, List, Any
+import os
+from typing import Any, Dict, List, Union
+
+import correctionlib
+import ROOT
 
 
 class FakeFactorEvaluator:

--- a/helper/ff_functions.py
+++ b/helper/ff_functions.py
@@ -419,6 +419,7 @@ def fit_function(
         "poly_best": tuple(f"poly_{i}" for i in range(1, 6))
     }
 
+    _do_mc_subtr_unc = True
     try:
         _, _ = ff_hist_up, ff_hist_down
     except UnboundLocalError:

--- a/helper/ff_functions.py
+++ b/helper/ff_functions.py
@@ -410,27 +410,30 @@ def fit_function(
 
     graph = ROOT.TGraphAsymmErrors(nbins, x, y, 0, 0, error_y_down, error_y_up)
 
-    if isinstance(fit_option, list) and all("poly" in _name for _name in fit_option):
-        callable_expression = fitting_helper.get_wrapped_functions_from_fits(
-            graph=graph,
-            bounds=(bin_edges[0], bin_edges[-1]),
-            do_mc_subtr_unc=do_mc_subtr_unc,
-            ff_hist_up=ff_hist_up,
-            ff_hist_down=ff_hist_down,
-            function_collection=fit_option,
-            convert_to_callable=True,
-        )
-        correctionlib_expression = fitting_helper.get_wrapped_functions_from_fits(
-            graph=graph,
-            bounds=(bin_edges[0], bin_edges[-1]),
-            do_mc_subtr_unc=do_mc_subtr_unc,
-            ff_hist_up=ff_hist_up,
-            ff_hist_down=ff_hist_down,
-            function_collection=fit_option,
-            convert_to_callable=False,
-        )
-    elif fit_option == "bin_wise":
-        raise NotImplementedError("bin_wise fit option is not implemented yet")
+    retrival_function = fitting_helper.get_wrapped_functions_from_fits
+    if fit_option == "bin_wise":
+        retrival_function = fitting_helper.get_wrapped_hists
+
+    callable_expression = retrival_function(
+        graph=graph,
+        bounds=(bin_edges[0], bin_edges[-1]),
+        do_mc_subtr_unc=do_mc_subtr_unc,
+        ff_hist=ff_hist,
+        ff_hist_up=ff_hist_up,
+        ff_hist_down=ff_hist_down,
+        function_collection=fit_option,
+        convert_to_callable=True,
+    )
+    correctionlib_expression = retrival_function(
+        graph=graph,
+        bounds=(bin_edges[0], bin_edges[-1]),
+        do_mc_subtr_unc=do_mc_subtr_unc,
+        ff_hist=ff_hist,
+        ff_hist_up=ff_hist_up,
+        ff_hist_down=ff_hist_down,
+        function_collection=fit_option,
+        convert_to_callable=False,
+    )
 
     # producing correctionlib expressions for nominal and all variation
     corrlib_expressions = dict()
@@ -473,7 +476,7 @@ def fit_function(
         y_fit_mc_down = array.array("d", y_fit_mc_down)
 
     results, _args = {}, (len(x_fit), x_fit, y_fit, 0, 0)
-    results["fit_graph_unct"] = ROOT.TGraphAsymmErrors(*_args, y_fit_down, y_fit_up)
+    results["fit_graph_unc"] = ROOT.TGraphAsymmErrors(*_args, y_fit_down, y_fit_up)
     if do_mc_subtr_unc:
         results["fit_graph_mc_sub"] = ROOT.TGraphAsymmErrors(*_args, y_fit_mc_down, y_fit_mc_up)
 

--- a/helper/ff_functions.py
+++ b/helper/ff_functions.py
@@ -411,44 +411,44 @@ def fit_function(
     graph = ROOT.TGraphAsymmErrors(nbins, x, y, 0, 0, error_y_down, error_y_up)
 
     if isinstance(fit_option, list) and all("poly" in _name for _name in fit_option):
-        callable_functions = fitting_helper.get_wrapped_functions_from_fits(
+        callable_expression = fitting_helper.get_wrapped_functions_from_fits(
             graph=graph,
             bounds=(bin_edges[0], bin_edges[-1]),
             do_mc_subtr_unc=do_mc_subtr_unc,
             ff_hist_up=ff_hist_up,
             ff_hist_down=ff_hist_down,
             function_collection=fit_option,
-            convert_to="ROOT",
+            convert_to_callable=True,
         )
-        str_functions = fitting_helper.get_wrapped_functions_from_fits(
+        correctionlib_expression = fitting_helper.get_wrapped_functions_from_fits(
             graph=graph,
             bounds=(bin_edges[0], bin_edges[-1]),
             do_mc_subtr_unc=do_mc_subtr_unc,
             ff_hist_up=ff_hist_up,
             ff_hist_down=ff_hist_down,
             function_collection=fit_option,
-            convert_to="str",
+            convert_to_callable=False,
         )
     elif fit_option == "bin_wise":
         raise NotImplementedError("bin_wise fit option is not implemented yet")
 
     # producing correctionlib expressions for nominal and all variation
     corrlib_expressions = dict()
-    corrlib_expressions["nominal"] = str_functions["nominal"]  # best fit
-    corrlib_expressions["unc_up"] = str_functions["up"]  # up variation of best fit
-    corrlib_expressions["unc_down"] = str_functions["down"]  # down variation of best fit
+    corrlib_expressions["nominal"] = correctionlib_expression["nominal"]  # best fit
+    corrlib_expressions["unc_up"] = correctionlib_expression["up"]  # up variation of best fit
+    corrlib_expressions["unc_down"] = correctionlib_expression["down"]  # down variation of best fit
     if do_mc_subtr_unc:  # MC subtraction uncertainty up/down
-        corrlib_expressions["mc_subtraction_unc_up"] = str_functions["mc_up"]
-        corrlib_expressions["mc_subtraction_unc_down"] = str_functions["mc_down"]
+        corrlib_expressions["mc_subtraction_unc_up"] = correctionlib_expression["mc_up"]
+        corrlib_expressions["mc_subtraction_unc_down"] = correctionlib_expression["mc_down"]
 
     # producing graphs of the fit results for the plots with more bins than the used histograms
-    fit_func = lambda pt: callable_functions["nominal"](pt)  # noqa E731
-    fit_func_up = lambda pt: callable_functions["up"](pt)  # noqa E731
-    fit_func_down = lambda pt: callable_functions["down"](pt)  # noqa E731
+    fit_func = lambda pt: callable_expression["nominal"](pt)  # noqa E731
+    fit_func_up = lambda pt: callable_expression["up"](pt)  # noqa E731
+    fit_func_down = lambda pt: callable_expression["down"](pt)  # noqa E731
 
     if do_mc_subtr_unc:
-        fit_func_mc_up = lambda pt: callable_functions["mc_up"](pt)  # noqa E731
-        fit_func_mc_down = lambda pt: callable_functions["mc_down"](pt)  # noqa E731
+        fit_func_mc_up = lambda pt: callable_expression["mc_up"](pt)  # noqa E731
+        fit_func_mc_down = lambda pt: callable_expression["mc_down"](pt)  # noqa E731
 
     y_fit, y_fit_up, y_fit_down = [], [], []
     if do_mc_subtr_unc:

--- a/helper/ff_functions.py
+++ b/helper/ff_functions.py
@@ -411,14 +411,60 @@ def fit_function(
     log.info("-" * 50)
 
     # --------------------------------------------------------------------------------------
-    # _functions = fitting_helper.get_wrapped_functions_from_fits(
-    #     graph=graph,
-    #     bounds=(bin_edges[0], bin_edges[-1]),
-    #     do_mc_subtr_unc=do_mc_subtr_unc,
-    #     ff_hist_up=ff_hist_up,
-    #     ff_hist_down=ff_hist_down,
-    # )
+    function_fit_option = "poly_best"
+    function_fit_options = {
+        **{
+            f"poly_{i}": (f"poly_{i}",) for i in range(1, 6)
+        },
+        "poly_best": tuple(f"poly_{i}" for i in range(1, 6))
+    }
+
+    try:
+        _, _ = ff_hist_up, ff_hist_down
+    except UnboundLocalError:
+        ff_hist_up, ff_hist_down = None, None
+        _do_mc_subtr_unc = False
+
+    _functions = fitting_helper.get_wrapped_functions_from_fits(
+        graph=graph,
+        bounds=(bin_edges[0], bin_edges[-1]),
+        do_mc_subtr_unc=do_mc_subtr_unc and _do_mc_subtr_unc,
+        ff_hist_up=ff_hist_up,
+        ff_hist_down=ff_hist_down,
+        function_collection=function_fit_options[function_fit_option],
+        convert_to="ROOT",
+    )
+    _functions_str = fitting_helper.get_wrapped_functions_from_fits(
+        graph=graph,
+        bounds=(bin_edges[0], bin_edges[-1]),
+        do_mc_subtr_unc=do_mc_subtr_unc and _do_mc_subtr_unc,
+        ff_hist_up=ff_hist_up,
+        ff_hist_down=ff_hist_down,
+        function_collection=function_fit_options[function_fit_option],
+        convert_to="str",
+    )
     # TODO: start from here
+
+    c1 = ROOT.TCanvas("c", "", 700, 800)
+    f1 = _functions["nominal"]
+    f2 = _functions["up"]
+    f3 = _functions["down"]
+    f1.SetLineColor(ROOT.kRed)
+    f2.SetLineColor(ROOT.kBlue)
+    f3.SetLineColor(ROOT.kGreen)
+    f1.Draw()
+    f2.Draw("SAME")
+    f3.Draw("SAME")
+    graph.Draw("E SAME")
+
+    import os
+    __i = 0
+    while os.path.exists(f"test{__i}.png"):
+        __i += 1
+
+    c1.SaveAs(f"test{__i}.png")
+
+    # import ipdb; ipdb.set_trace()
 
     # --------------------------------------------------------------------------------------
     # producing correctionlib expressions for nominal and all variation

--- a/helper/ff_functions.py
+++ b/helper/ff_functions.py
@@ -3,16 +3,12 @@ Collection of helpful functions for the fake factor calculation scripts
 """
 
 import array
+from typing import Any, Dict, List, Tuple, Union
+
 import numpy as np
 import ROOT
-from io import StringIO
-from wurlitzer import pipes, STDOUT
-import logging
-from typing import List, Dict, Union, Tuple, Any, Callable
-import itertools as itt
-import numdifftools as nd
-import helper.fitting_helper as fitting_helper
 
+import helper.fitting_helper as fitting_helper
 import helper.weights as weights
 
 

--- a/helper/ff_functions.py
+++ b/helper/ff_functions.py
@@ -639,3 +639,4 @@ def smooth_function(
         len(smooth_x), smooth_x, smooth_y, 0, 0, smooth_y_down, smooth_y_up
     )
     return smooth_graph, corr_dict
+

--- a/helper/ff_functions.py
+++ b/helper/ff_functions.py
@@ -8,7 +8,10 @@ import ROOT
 from io import StringIO
 from wurlitzer import pipes, STDOUT
 import logging
-from typing import List, Dict, Union, Tuple, Any
+from typing import List, Dict, Union, Tuple, Any, Callable
+import itertools as itt
+import numdifftools as nd
+import helper.fitting_helper as fitting_helper
 
 import helper.weights as weights
 
@@ -407,6 +410,17 @@ def fit_function(
     log.info(out.getvalue())
     log.info("-" * 50)
 
+    # --------------------------------------------------------------------------------------
+    # _functions = fitting_helper.get_wrapped_functions_from_fits(
+    #     graph=graph,
+    #     bounds=(bin_edges[0], bin_edges[-1]),
+    #     do_mc_subtr_unc=do_mc_subtr_unc,
+    #     ff_hist_up=ff_hist_up,
+    #     ff_hist_down=ff_hist_down,
+    # )
+    # TODO: start from here
+
+    # --------------------------------------------------------------------------------------
     # producing correctionlib expressions for nominal and all variation
     corrlib_expressions = dict()
     # best fit

--- a/helper/ff_functions.py
+++ b/helper/ff_functions.py
@@ -414,9 +414,9 @@ def fit_function(
     function_fit_option = "poly_best"
     function_fit_options = {
         **{
-            f"poly_{i}": (f"poly_{i}",) for i in range(1, 6)
+            f"poly_{i}": (f"poly_{i}",) for i in range(0, 6)
         },
-        "poly_best": tuple(f"poly_{i}" for i in range(1, 6))
+        "poly_best": tuple(f"poly_{i}" for i in range(0, 6))
     }
 
     _do_mc_subtr_unc = True

--- a/helper/fitting_helper.py
+++ b/helper/fitting_helper.py
@@ -141,8 +141,9 @@ def get_wrapped_functions_from_fits(
     ),
     verbose: bool = True,
     logger: Union[str, None] = None,
-    convert_to: Literal["ROOT", "str"] = "ROOT",
-) -> Dict[str, ROOT.TF1]:
+    convert_to_callable: bool = True,
+    **kwargs: Dict[str, Any],
+) -> Dict[str, Union[ROOT.TF1, str, Callable]]:
     """
     Fits a set of functions to a given graph and returns functions
     (nominal, nominal + error, nominal - error) for the best fit.
@@ -236,10 +237,10 @@ def get_wrapped_functions_from_fits(
     par, cov = extract_par_and_cov(Fits[name])
     for _k, _func, _vars in zip(
         ["nominal", "up", "down"],
-        (generated_functions if convert_to == "ROOT" else generated_str_functions)[name],
+        (generated_functions if convert_to_callable == convert_to_callable else generated_str_functions)[name],
         [par, [*par, *cov.flatten()], [*par, *cov.flatten()]],
     ):
-        if convert_to == "ROOT":
+        if convert_to_callable == convert_to_callable:
             results[_k] = ROOT.TF1(f"{_func.__name__}_{_k}", _func, a, b, _func.__n_par__)
             for i, p in enumerate(_vars):
                 results[_k].SetParameter(i, p)
@@ -249,12 +250,12 @@ def get_wrapped_functions_from_fits(
     if do_mc_subtr_unc:
         par_up, _ = extract_par_and_cov(Fits_up[name])
         par_down, _ = extract_par_and_cov(Fits_down[name])
-        _func, _, _ = (generated_functions if convert_to == "ROOT" else generated_str_functions)[name]
+        _func, _, _ = (generated_functions if convert_to_callable == convert_to_callable else generated_str_functions)[name]
         for _k, _vars in zip(
             ("mc_up", "mc_down"),
             (par_up, par_down)
         ):
-            if convert_to == "ROOT":
+            if convert_to_callable == convert_to_callable:
                 results[_k] = ROOT.TF1(f"{_func.__name__}_{_k}", _func, a, b, _func.__n_par__)
                 for i, p in enumerate(_vars):
                     results[_k].SetParameter(i, p)

--- a/helper/fitting_helper.py
+++ b/helper/fitting_helper.py
@@ -1,0 +1,168 @@
+import numpy as np
+import itertools as itt
+import numdifftools as nd
+from typing import Any, Callable, Tuple
+try:
+    import ROOT
+except ImportError:
+    class FakeROOT:
+        TF1 = None
+        TGraphAsymmErrors = None
+        TH1 = None
+    ROOT = FakeROOT
+
+
+class FitFunctions:
+    @staticmethod
+    def poly_1(x, par):
+        return par[0] + par[1] * x[0]
+
+    @staticmethod
+    def poly_2(x, par):
+        return par[0] + par[1] * x[0] + par[2] * x[0] ** 2
+
+    @staticmethod
+    def poly_3(x, par):
+        return par[0] + par[1] * x[0] + par[2] * x[0] ** 2 + par[3] * x[0] ** 3
+
+    @staticmethod
+    def poly_4(x, par):
+        return par[0] + par[1] * x[0] + par[2] * x[0] ** 2 + par[3] * x[0] ** 3 + par[4] * x[0] ** 4
+
+    @staticmethod
+    def poly_5(x, par):
+        return par[0] + par[1] * x[0] + par[2] * x[0] ** 2 + par[3] * x[0] ** 3 + par[4] * x[0] ** 4 + par[5] * x[0] ** 5
+
+
+FitFunctions.poly_1.__n_par__ = 2
+FitFunctions.poly_2.__n_par__ = 3
+FitFunctions.poly_3.__n_par__ = 4
+FitFunctions.poly_4.__n_par__ = 5
+FitFunctions.poly_5.__n_par__ = 6
+
+
+def _extract_par(fit: Any) -> np.ndarray:
+    return np.array(
+        [
+            fit.Get().Parameter(i)
+            for i in range(fit.Get().Parameters().size())
+        ],
+    )
+
+
+def _extract_cov(fit: Any) -> np.ndarray:
+    N = fit.Get().Parameters().size()
+    cov, _cov = np.zeros((N, N)), fit.Get().GetCovarianceMatrix()
+    for i, j in itt.product(range(N), range(N)):
+        cov[i, j] = _cov(i, j)
+    return cov
+
+
+def extract_par_and_cov(fit: Any) -> Tuple[np.ndarray, np.ndarray]:
+    return _extract_par(fit), _extract_cov(fit)
+
+
+def get_wrapped_error_funcs(func, par, cov):
+    def upper_value(x):
+        return func(x, par) + np.sqrt(
+            np.apply_along_axis(
+                lambda J: J @ cov @ J.T,
+                1,
+                np.atleast_2d(nd.Gradient(lambda par: func(x, par))(par)),
+            ),
+        ) / 2
+
+    def lower_value(x):
+        return func(x, par) - np.sqrt(
+            np.apply_along_axis(
+                lambda J: J @ cov @ J.T,
+                1,
+                np.atleast_2d(nd.Gradient(lambda par: func(x, par))(par)),
+            ),
+        ) / 2
+
+    return upper_value, lower_value
+
+
+def get_wrapped_func(func, par):
+    def _f(x):
+        return func(x, par)
+    return _f
+
+
+def get_wrapped_functions_from_fits(
+    graph: ROOT.TGraphAsymmErrors,
+    bounds: Tuple[float, float],
+    do_mc_subtr_unc: bool,
+    ff_hist_up: ROOT.TH1,
+    ff_hist_down: ROOT.TH1,
+    function_collection: Tuple[Callable, ...] = (
+        FitFunctions.poly_1,
+        FitFunctions.poly_2,
+        FitFunctions.poly_3,
+        FitFunctions.poly_4,
+        FitFunctions.poly_5,
+    ),
+    verbose: bool = True,
+    root_wrap: bool = True,
+) -> Tuple[Tuple[Tuple[Callable, Callable, Callable], ...]]:
+
+    a, b = bounds
+    TF1s, Fits = dict(), dict()
+    best_chi2_over_ndf, name = float("inf"), ""
+    TF1s_up, TF1s_down, Fits_up, Fits_down = dict(), dict(), dict(), dict()
+
+    for _f in function_collection:
+        TF1s[_f.__name__] = ROOT.TF1(_f.__name__, _f, a, b, _f.__n_par__)
+        Fits[_f.__name__] = graph.Fit(TF1s[_f.__name__], "SFN")
+
+        chi2_over_ndf = Fits[_f.__name__].Chi2() / Fits[_f.__name__].Ndf()
+        if abs(chi2_over_ndf - 1) < abs(best_chi2_over_ndf - 1):
+            best_chi2_over_ndf = chi2_over_ndf
+            name = _f.__name__
+
+            if do_mc_subtr_unc:
+                TF1s_up[_f.__name__] = ROOT.TF1(_f.__name__, _f, a, b, _f.__n_par__)
+                TF1s_down[_f.__name__] = ROOT.TF1(_f.__name__, _f, a, b, _f.__n_par__)
+
+                Fits_up[_f.__name__] = ff_hist_up.Fit(TF1s_up[_f.__name__], "SFN")
+                Fits_down[_f.__name__] = ff_hist_down.Fit(TF1s_down[_f.__name__], "SFN")
+
+    if verbose:
+        # TODO add logging
+        pass
+
+    _func, (_par, _cov) = getattr(FitFunctions, name), extract_par_and_cov(Fits[name])
+    results = [
+        (
+            get_wrapped_func(_func, _par),
+            *get_wrapped_error_funcs(_func, _par, _cov),
+        ),
+    ]
+
+    if do_mc_subtr_unc:
+        _par_up, _cov_up = extract_par_and_cov(Fits_up[name])
+        _par_down, _cov_down = extract_par_and_cov(Fits_down[name])
+
+        results.extend(
+            [
+                (
+                    get_wrapped_func(_func, _par_up),
+                    *get_wrapped_error_funcs(_func, _par_up, _cov_up),
+                ),
+                (
+                    get_wrapped_func(_func, _par_down),
+                    *get_wrapped_error_funcs(_func, _par_down, _cov_down),
+                ),
+            ]
+        )
+    if root_wrap:
+        results = tuple(
+            (
+                ROOT.TF1(f"{f.__name__}_{n}", f, a, b, 0),
+                ROOT.TF1(f"{f.__name__}_{n}_up", f, a, b, 0),
+                ROOT.TF1(f"{f.__name__}_{n}_down", f, a, b, 0),
+            )
+            for f, n in zip(results, [""] if not do_mc_subtr_unc else ["", "_up", "_down"])
+        )
+    return tuple(results)

--- a/helper/fitting_helper.py
+++ b/helper/fitting_helper.py
@@ -1,5 +1,7 @@
 import itertools as itt
 import logging
+from copy import deepcopy
+from functools import partial
 from io import StringIO
 from typing import Any, Callable, Dict, List, Tuple, Union
 
@@ -8,54 +10,126 @@ import ROOT
 from wurlitzer import STDOUT, pipes
 
 
-def func_yerr(x, par, n, func):
-    grad, eps, func_par = [], 1e-6, [par[i] for i in range(n)]
-    cov = [[par[n + i * n + j] for j in range(n)] for i in range(n)]
+def _get_gradients(
+    x: Union[List[float], str],
+    par: List[float],
+    n: int,
+    func: Callable,
+    is_string: bool = False,
+) -> Union[List[float], List[str]]:
+    grad, eps = [], 1e-6
     for i in range(n):
-        func_par1 = [func_par[i] for i in range(n)]
-        func_par2 = [func_par[i] for i in range(n)]
-        func_par1[i] += eps
-        func_par2[i] -= eps
-        grad.append((func(x, func_par1) - func(x, func_par2)) / (2 * eps))
+        par1, par2 = deepcopy(par), deepcopy(par)
+        par1[i] += eps
+        par2[i] -= eps
+        if is_string:
+            grad.append(f"(({func(x, par1)} - {func(x, par2)}) / (2.0 * {eps}))")
+        else:
+            grad.append((func(x, par1) - func(x, par2)) / (2 * eps))
+    return grad
+
+
+def func_yerr(
+    x: Union[List[float], str],
+    par: List[float],
+    n: int,
+    func: Callable
+) -> float:
+    # par contains func parameters and the flattened covariance matrix
+    grad = _get_gradients(x, [par[i] for i in range(n)], n, func, is_string=False)
+    cov = [[par[n + i * n + j] for j in range(n)] for i in range(n)]
     variance = sum(sum(grad[i] * cov[i][j] * grad[j] for j in range(n)) for i in range(n))
     variance = (variance ** (2)) ** 0.5
     return (variance) ** 0.5
 
 
-def str_func_yerr(x, par, n, func):
-    grad, eps, func_par = [], 1e-6, [par[i] for i in range(n)]
+def str_func_yerr(
+    x: Union[List[float], List[str]],
+    par: List[float],
+    n: int,
+    func: Callable
+) -> str:
+    # par contains func parameters and the flattened covariance matrix
+    grad = _get_gradients(x, [par[i] for i in range(n)], n, func, is_string=True)
     cov = [[par[n + i * n + j] for j in range(n)] for i in range(n)]
-    for i in range(n):
-        func_par1 = [func_par[i] for i in range(n)]
-        func_par2 = [func_par[i] for i in range(n)]
-        func_par1[i] += eps
-        func_par2[i] -= eps
-        grad.append(f"(({func(x, func_par1)} - {func(x, func_par2)}) / (2.0 * {eps}))")
     variance = " + ".join(" + ".join(f"(({grad[i]}) * ({cov[i][j]}) * ({grad[j]}))" for j in range(n)) for i in range(n))
     variance = f"pow(pow({variance}, 2), 0.5)"
     return f"pow({variance}, 0.5)"
 
 
-def poly_n_func(n: int) -> Tuple[Callable, Callable]:
+def _limit(
+    value: Union[float, str],
+    *boundaries: float,
+    is_string: bool = False,
+) -> Union[float, str]:
+    assert len(boundaries) == 2, "Boundaries must be a tuple of two (lower, upper) float values."
+    minimum, maximum = boundaries
+    if is_string:
+        minimum = "-9999.0" if minimum == -float("inf") else str(float(minimum))
+        maximum = "9999.0" if maximum == float("inf") else str(float(maximum))
+        return f"(max(min({value}, {maximum}), {minimum}))"
+    else:
+        return max(min(value, maximum), minimum)
+
+
+_no_limit_default = (-float("inf"), float("inf"))
+
+
+def poly_n_func(
+    n: int,
+    #
+    limit_x_nominal: Tuple[float, float] = _no_limit_default,
+    limit_x_up: Tuple[float, float] = _no_limit_default,
+    limit_x_down: Tuple[float, float] = _no_limit_default,
+    #
+    limit_y_nominal: Tuple[float, float] = _no_limit_default,
+    limit_y_up: Tuple[float, float] = _no_limit_default,
+    limit_y_down: Tuple[float, float] = _no_limit_default,
+    #
+    boundary_replace_nominal: Union[Tuple[None, ...], Tuple[Any, Any]] = (None,),  # tbd
+    boundary_replace_up: Union[Tuple[None, ...], Tuple[Any, Any]] = (None,),  # tbd
+    boundary_replace_down: Union[Tuple[None, ...], Tuple[Any, Any]] = (None,),  # tbd
+) -> Tuple[Callable, Callable, Callable]:
 
     def nominal(x, par):
-        return sum(par[i] * x[0] ** i for i in range(n + 1))
+        if not any(boundary_replace_nominal):
+            x = [_limit(x[0], *limit_x_nominal)]
+            nom = sum(par[i] * x[0] ** i for i in range(n + 1))
+            return _limit(nom, *limit_y_nominal)
+        else:
+            raise NotImplementedError
 
     nominal.__name__ = f"poly_{n}"
     nominal.__n_par__ = n + 1
 
     def up(x, par):
-        nom = nominal(x, [par[i] for i in range(n + 1)])
-        unct = func_yerr(x, par, n + 1, nominal)
-        return nom + unct / 2.0
+        # due to ROOT it cannot be defined in outer scope
+        def _nominal(x, par):
+            return sum(par[i] * x[0] ** i for i in range(n + 1))
+
+        if not any(boundary_replace_up):
+            x = [_limit(x[0], *limit_x_up)]
+            nom = _nominal(x, [par[i] for i in range(nominal.__n_par__)])
+            unct = func_yerr(x, par, nominal.__n_par__, _nominal)
+            return _limit(nom + unct / 2.0, *limit_y_up)
+        else:
+            raise NotImplementedError
 
     up.__name__ = f"poly_{n}_up"
     up.__n_par__ = (n + 1) + (n + 1) * (n + 1)
 
     def down(x, par):
-        nom = nominal(x, [par[i] for i in range(n + 1)])
-        unct = func_yerr(x, par, n + 1, nominal)
-        return nom - unct / 2.0
+        # due to ROOT it cannot be defined in outer scope
+        def _nominal(x, par):
+            return sum(par[i] * x[0] ** i for i in range(n + 1))
+
+        if not any(boundary_replace_down):
+            x = [_limit(x[0], *limit_x_down)]
+            nom = _nominal(x, [par[i] for i in range(nominal.__n_par__)])
+            unct = func_yerr(x, par, nominal.__n_par__, _nominal)
+            return _limit(nom - unct / 2.0, *limit_y_down)
+        else:
+            raise NotImplementedError
 
     down.__name__ = f"poly_{n}_down"
     down.__n_par__ = (n + 1) + (n + 1) * (n + 1)
@@ -63,27 +137,57 @@ def poly_n_func(n: int) -> Tuple[Callable, Callable]:
     return nominal, up, down
 
 
-def poly_n_str_func(n: int) -> Tuple[Callable, Callable]:
+def poly_n_str_func(
+    n: int,
+    #
+    limit_x_nominal: Tuple[float, float] = _no_limit_default,
+    limit_x_up: Tuple[float, float] = _no_limit_default,
+    limit_x_down: Tuple[float, float] = _no_limit_default,
+    #
+    limit_y_nominal: Tuple[float, float] = _no_limit_default,
+    limit_y_up: Tuple[float, float] = _no_limit_default,
+    limit_y_down: Tuple[float, float] = _no_limit_default,
+    #
+    boundary_replace_nominal: Union[Tuple[None, ...], Tuple[Any, Any]] = (None,),  # tbd
+    boundary_replace_up: Union[Tuple[None, ...], Tuple[Any, Any]] = (None,),  # tbd
+    boundary_replace_down: Union[Tuple[None, ...], Tuple[Any, Any]] = (None,),  # tbd
+) -> Tuple[Callable, Callable, Callable]:
 
-    def nominal(x, par_nominal):
-        expr = " + ".join((f"{par_nominal[i]} * pow({x}, {i})" for i in range(n + 1)))
-        return f"( {expr} )"
+    def _nominal(x, par):
+        nom = " + ".join((f"{par[i]} * pow({x}, {i})" for i in range(n + 1)))
+        return f"({nom})"
+
+    def nominal(x, par):
+        if not any(boundary_replace_nominal):
+            x = _limit(x, *limit_x_nominal, is_string=True)
+            nom = " + ".join((f"{par[i]} * pow({x}, {i})" for i in range(n + 1)))
+            return _limit(f"({nom})", *limit_y_nominal, is_string=True)
+        else:
+            raise NotImplementedError
 
     nominal.__name__ = f"poly_{n}"
     nominal.__n_par__ = n + 1
 
-    def up(x, par_up):
-        _nom_up = nominal(x, [par_up[i] for i in range(nominal.__n_par__)])
-        _up = str_func_yerr(x, par_up, nominal.__n_par__, nominal)
-        return f"( ( {_nom_up} ) + ( {_up} ) / 2.0 )"
+    def up(x, par):
+        if not any(boundary_replace_up):
+            x = _limit(x, *limit_x_up, is_string=True)
+            nom = _nominal(x, [par[i] for i in range(nominal.__n_par__)])
+            unct = str_func_yerr(x, par, nominal.__n_par__, _nominal)
+            return _limit(f"(({nom}) + ({unct}) / 2.0)", *limit_y_up, is_string=True)
+        else:
+            raise NotImplementedError
 
     up.__name__ = f"poly_{n}_up"
     up.__n_par__ = (n + 1) + (n + 1) * (n + 1)
 
-    def down(x, par_down):
-        _nom_down = nominal(x, [par_down[i] for i in range(nominal.__n_par__)])
-        _down = str_func_yerr(x, par_down, nominal.__n_par__, nominal)
-        return f"( ( {_nom_down} ) - ( {_down} ) / 2.0 )"
+    def down(x, par):
+        if not any(boundary_replace_down):
+            x = _limit(x, *limit_x_down, is_string=True)
+            nom = _nominal(x, [par[i] for i in range(nominal.__n_par__)])
+            unct = str_func_yerr(x, par, nominal.__n_par__, _nominal)
+            return _limit(f"(({nom}) - ({unct}) / 2.0)", *limit_y_down, is_string=True)
+        else:
+            raise NotImplementedError
 
     down.__name__ = f"poly_{n}_down"
     down.__n_par__ = (n + 1) + (n + 1) * (n + 1)
@@ -107,11 +211,6 @@ def extract_par_and_cov(fit: Any) -> Tuple[np.ndarray, np.ndarray]:
     return par, cov
 
 
-generated_functions, generated_str_functions = {}, {}
-generated_functions.update({f"poly_{i}": poly_n_func(i) for i in range(0, 6)})
-generated_str_functions.update({f"poly_{i}": poly_n_str_func(i) for i in range(0, 6)})
-
-
 def check_function_validity_within_bounds(
     funcs: Dict[str, Callable[..., List[float]]],
     bounds: Tuple[float, float],
@@ -124,6 +223,67 @@ def check_function_validity_within_bounds(
         # "down",  # TODO: is this needed?
     ]
     return all(all(funcs[k]([it], parameters[k]) > 0 for it in x) for k in keys)
+
+
+def get_default_limit_and_replace_kwargs(
+    bounds: Tuple[float, float],
+    limit_x: Union[Tuple[float, float], Dict[str, Tuple[float, float]]] = _no_limit_default,
+    limit_y: Union[Tuple[float, float], Dict[str, Tuple[float, float]]] = _no_limit_default,
+    boundary_replace: Union[Tuple[None, ...], Dict[str, Tuple[None, ...]]] = (None,),  # tbd
+    verbose: bool = True,
+    logger: Union[str, None] = None,
+) -> Dict[str, Union[Tuple[float, float], Tuple[None, ...]]]:
+    kwargs_dict = dict(
+        limit_x_nominal=limit_x if isinstance(limit_x, tuple) else limit_x.get("nominal", _no_limit_default),
+        limit_x_up=limit_x if isinstance(limit_x, tuple) else limit_x.get("up", _no_limit_default),
+        limit_x_down=limit_x if isinstance(limit_x, tuple) else limit_x.get("down", _no_limit_default),
+        limit_y_nominal=limit_y if isinstance(limit_y, tuple) else limit_y.get("nominal", _no_limit_default),
+        limit_y_up=limit_y if isinstance(limit_y, tuple) else limit_y.get("up", _no_limit_default),
+        limit_y_down=limit_y if isinstance(limit_y, tuple) else limit_y.get("down", _no_limit_default),
+        boundary_replace_nominal=boundary_replace if isinstance(boundary_replace, tuple) else boundary_replace.get("nominal", (None,)),
+        boundary_replace_up=boundary_replace if isinstance(boundary_replace, tuple) else boundary_replace.get("up", (None,)),
+        boundary_replace_down=boundary_replace if isinstance(boundary_replace, tuple) else boundary_replace.get("down", (None,)),
+    )
+
+    if (isinstance(limit_x, tuple) and limit_x == _no_limit_default):
+        msg = " ".join(
+            [
+                f"No custom limit_x was provided, using provided boundaries {bounds} for ",
+                "nominal, up and down functions",
+            ],
+        )
+        if verbose:
+            print(msg)
+        if logger is not None:
+            logger.info(msg)
+
+        kwargs_dict.update(
+            dict(
+                limit_x_nominal=bounds,
+                limit_x_up=bounds,
+                limit_x_down=bounds,
+            ),
+        )
+    if (isinstance(limit_y, tuple) and limit_y == _no_limit_default):
+        msg = " ".join(
+            [
+                f"No custom limit_y was provided, using default of (0.0, float('inf')) for ",
+                "nominal, up and down functions",
+            ],
+        )
+        if verbose:
+            print(msg)
+        if logger is not None:
+            logger.info(msg)
+
+        kwargs_dict.update(
+            dict(
+                limit_y_nominal=(0.0, float("inf")),
+                limit_y_up=(0.0, float("inf")),
+                limit_y_down=(0.0, float("inf")),
+            ),
+        )
+    return kwargs_dict
 
 
 def get_wrapped_functions_from_fits(
@@ -141,9 +301,13 @@ def get_wrapped_functions_from_fits(
     ),
     verbose: bool = True,
     logger: Union[str, None] = None,
-    convert_to_callable: bool = True,
+    #
+    limit_x: Union[Tuple[float, float], Dict[str, Tuple[float, float]]] = _no_limit_default,
+    limit_y: Union[Tuple[float, float], Dict[str, Tuple[float, float]]] = _no_limit_default,
+    boundary_replace: Union[Tuple[None, ...], Dict[str, Tuple[None, ...]]] = (None,),  # tbd
+    #
     **kwargs: Dict[str, Any],
-) -> Dict[str, Union[ROOT.TF1, str, Callable]]:
+) -> Tuple[Dict[str, Callable], Dict[str, str]]:
     """
     Fits a set of functions to a given graph and returns functions
     (nominal, nominal + error, nominal - error) for the best fit.
@@ -172,8 +336,32 @@ def get_wrapped_functions_from_fits(
     best_chi2_over_ndf, name = float("inf"), ""
     TF1s_up, TF1s_down, Fits_up, Fits_down = dict(), dict(), dict(), dict()
 
+    limit_and_replace_kwargs = get_default_limit_and_replace_kwargs(
+        bounds=bounds,
+        limit_x=limit_x,
+        limit_y=limit_y,
+        boundary_replace=boundary_replace,
+        verbose=verbose,
+        logger=logger,
+    )
+
+    poly_n_func_limited = partial(poly_n_func, **limit_and_replace_kwargs)
+    poly_n_str_func_limited = partial(poly_n_str_func, **limit_and_replace_kwargs)
+
+    _functions, _str_functions = dict(), dict()
+    _functions_limited, _str_functions_limited = dict(), dict()
+    for func in function_collection:
+        if "poly_" in func:
+            n = int(func.split("_")[-1])
+            _functions[func] = poly_n_func(n)
+            _str_functions[func] = poly_n_str_func(n)
+            _functions_limited[func] = poly_n_func_limited(n)
+            _str_functions_limited[func] = poly_n_str_func_limited(n)
+        else:
+            raise ValueError(f"Unknown/unsupported function: {func}")
+
     for func_collection_name in function_collection:
-        func, _, _ = generated_functions[func_collection_name]
+        func, _, _ = _functions[func_collection_name]
         func_name, n_pars = func.__name__, func.__n_par__
         TF1s[func_name] = ROOT.TF1(func_name, func, a, b, n_pars)
         Fits[func_name] = graph.Fit(TF1s[func_name], "SFN")
@@ -185,7 +373,7 @@ def get_wrapped_functions_from_fits(
 
         __par, __cov = extract_par_and_cov(Fits[func_name])
         if not check_function_validity_within_bounds(
-            funcs=dict(zip(["nominal", "up", "down"], generated_functions[func_name])),
+            funcs=dict(zip(["nominal", "up", "down"], _functions[func_name])),
             bounds=bounds,
             parameters=dict(
                 zip(
@@ -232,37 +420,36 @@ def get_wrapped_functions_from_fits(
             log.info(out.getvalue())
             log.info("-" * 50)
 
-    results = {}
+    callable_results, str_results = {}, {}
 
-    par, cov = extract_par_and_cov(Fits[name])
-    for _k, _func, _vars in zip(
-        ["nominal", "up", "down"],
-        (generated_functions if convert_to_callable else generated_str_functions)[name],
-        [par, [*par, *cov.flatten()], [*par, *cov.flatten()]],
-    ):
-        if convert_to_callable:
-            results[_k] = ROOT.TF1(f"{_func.__name__}_{_k}", _func, a, b, _func.__n_par__)
-            for i, p in enumerate(_vars):
-                results[_k].SetParameter(i, p)
-        else:
-            results[_k] = _func(" ( x ) ", _vars)
+    nominal_par, cov = extract_par_and_cov(Fits[name])
+    variation_par = [*nominal_par, *cov.flatten()]
+
+    callable_results["nominal"] = lambda x: _functions_limited[name][0]([x], nominal_par)
+    callable_results["unc_up"] = lambda x: _functions_limited[name][1]([x], variation_par)
+    callable_results["unc_down"] = lambda x: _functions_limited[name][2]([x], variation_par)
+
+    str_results["nominal"] = _str_functions_limited[name][0](" ( x ) ", nominal_par)
+    str_results["unc_up"] = _str_functions_limited[name][1](" ( x ) ", variation_par)
+    str_results["unc_down"] = _str_functions_limited[name][2](" ( x ) ", variation_par)
 
     if do_mc_subtr_unc:
         par_up, _ = extract_par_and_cov(Fits_up[name])
         par_down, _ = extract_par_and_cov(Fits_down[name])
-        _func, _, _ = (generated_functions if convert_to_callable else generated_str_functions)[name]
-        for _k, _vars in zip(
-            ("mc_up", "mc_down"),
-            (par_up, par_down)
-        ):
-            if convert_to_callable:
-                results[_k] = ROOT.TF1(f"{_func.__name__}_{_k}", _func, a, b, _func.__n_par__)
-                for i, p in enumerate(_vars):
-                    results[_k].SetParameter(i, p)
-            else:
-                results[_k] = _func(" ( x ) ", _vars)
+        callable_results["mc_subtraction_unc_up"] = lambda x: _functions_limited[name][0](
+            [x], par_up,
+        )
+        callable_results["mc_subtraction_unc_down"] = lambda x: _functions_limited[name][0](
+            [x], par_down,
+        )
+        str_results["mc_subtraction_unc_up"] = _str_functions_limited[name][0](
+            " ( x ) ", par_up,
+        )
+        str_results["mc_subtraction_unc_down"] = _str_functions_limited[name][0](
+            " ( x ) ", par_down,
+        )
 
-    return results
+    return callable_results, str_results
 
 
 # ---
@@ -317,22 +504,28 @@ def get_wrapped_hists(
     ff_hist_up: ROOT.TH1,
     ff_hist_down: ROOT.TH1,
     do_mc_subtr_unc: bool,
-    convert_to_callable: bool = True,
+    _convert_to_callable: Union[None, bool] = None,  # if only one is needed
     **kwargs: Dict[str, Any],
 ) -> Dict[str, Union[ROOT.TF1, str, Callable]]:
 
-    results = dict(
-        zip(
-            ["nominal", "up", "down"],
-            _hist(ff_hist, return_callable=convert_to_callable),
+    if _convert_to_callable is None:
+        return (
+            get_wrapped_hists(ff_hist, ff_hist_up, ff_hist_down, do_mc_subtr_unc, _convert_to_callable=True),
+            get_wrapped_hists(ff_hist, ff_hist_up, ff_hist_down, do_mc_subtr_unc, _convert_to_callable=False),
         )
-    )
-    if do_mc_subtr_unc:
-        results.update(
-            {
-                "mc_up": _hist(ff_hist_up, return_callable=convert_to_callable)[0],
-                "mc_down": _hist(ff_hist_down, return_callable=convert_to_callable)[0],
-            }
+    else:
+        results = dict(
+            zip(
+                ["nominal", "unc_up", "unc_down"],
+                _hist(ff_hist, return_callable=_convert_to_callable),
+            )
         )
+        if do_mc_subtr_unc:
+            results.update(
+                {
+                    "mc_subtraction_unc_up": _hist(ff_hist_up, return_callable=_convert_to_callable)[0],
+                    "mc_subtraction_unc_down": _hist(ff_hist_down, return_callable=_convert_to_callable)[0],
+                }
+            )
 
-    return results
+        return results

--- a/helper/fitting_helper.py
+++ b/helper/fitting_helper.py
@@ -1,7 +1,7 @@
 import itertools as itt
 import logging
 from io import StringIO
-from typing import Any, Callable, Dict, List, Literal, Tuple, Union
+from typing import Any, Callable, Dict, List, Tuple, Union
 
 import numpy as np
 import ROOT

--- a/helper/fitting_helper.py
+++ b/helper/fitting_helper.py
@@ -237,10 +237,10 @@ def get_wrapped_functions_from_fits(
     par, cov = extract_par_and_cov(Fits[name])
     for _k, _func, _vars in zip(
         ["nominal", "up", "down"],
-        (generated_functions if convert_to_callable == convert_to_callable else generated_str_functions)[name],
+        (generated_functions if convert_to_callable else generated_str_functions)[name],
         [par, [*par, *cov.flatten()], [*par, *cov.flatten()]],
     ):
-        if convert_to_callable == convert_to_callable:
+        if convert_to_callable:
             results[_k] = ROOT.TF1(f"{_func.__name__}_{_k}", _func, a, b, _func.__n_par__)
             for i, p in enumerate(_vars):
                 results[_k].SetParameter(i, p)
@@ -250,12 +250,12 @@ def get_wrapped_functions_from_fits(
     if do_mc_subtr_unc:
         par_up, _ = extract_par_and_cov(Fits_up[name])
         par_down, _ = extract_par_and_cov(Fits_down[name])
-        _func, _, _ = (generated_functions if convert_to_callable == convert_to_callable else generated_str_functions)[name]
+        _func, _, _ = (generated_functions if convert_to_callable else generated_str_functions)[name]
         for _k, _vars in zip(
             ("mc_up", "mc_down"),
             (par_up, par_down)
         ):
-            if convert_to_callable == convert_to_callable:
+            if convert_to_callable:
                 results[_k] = ROOT.TF1(f"{_func.__name__}_{_k}", _func, a, b, _func.__n_par__)
                 for i, p in enumerate(_vars):
                     results[_k].SetParameter(i, p)

--- a/helper/fitting_helper.py
+++ b/helper/fitting_helper.py
@@ -32,8 +32,8 @@ def str_func_yerr(x, par, n, func):
         func_par2[i] -= eps
         grad.append(f"(({func(x, func_par1)} - {func(x, func_par2)}) / (2.0 * {eps}))")
     variance = " + ".join(" + ".join(f"(({grad[i]}) * ({cov[i][j]}) * ({grad[j]}))" for j in range(n)) for i in range(n))
-    variance = f"((({variance}) ** (2))) ** (0.5)"
-    return f"(({variance}) ** (0.5))"
+    variance = f"pow(pow({variance}, 2), 0.5)"
+    return f"pow({variance}, 0.5)"
 
 
 def poly_n_func(n: int) -> Tuple[Callable, Callable]:
@@ -66,7 +66,7 @@ def poly_n_func(n: int) -> Tuple[Callable, Callable]:
 def poly_n_str_func(n: int) -> Tuple[Callable, Callable]:
 
     def nominal(x, par):
-        expr = " + ".join(f"({par[i]} * ( x ) ** ({i}))" for i in range(n + 1))
+        expr = " + ".join((f"{par[i]} * pow( {x} , {i})" for i in range(n + 1)))
         return f"( {expr} )"
 
     nominal.__name__ = f"poly_{n}"
@@ -108,8 +108,8 @@ def extract_par_and_cov(fit: Any) -> Tuple[np.ndarray, np.ndarray]:
 
 
 generated_functions, generated_str_functions = {}, {}
-generated_functions.update({f"poly_{i}": poly_n_func(i) for i in range(1, 6)})
-generated_str_functions.update({f"poly_{i}": poly_n_str_func(i) for i in range(1, 6)})
+generated_functions.update({f"poly_{i}": poly_n_func(i) for i in range(0, 6)})
+generated_str_functions.update({f"poly_{i}": poly_n_str_func(i) for i in range(0, 6)})
 
 
 def get_wrapped_functions_from_fits(

--- a/helper/plotting.py
+++ b/helper/plotting.py
@@ -36,6 +36,12 @@ def plot_FFs(
     Return:
         None
     """
+
+    if isinstance(draw_option, str) and draw_option == "bin_wise":
+        draw_option = "hist"
+    else:
+        draw_option = "fit"
+
     log = logging.getLogger(logger)
 
     ROOT.PyConfig.IgnoreCommandLineOptions = True

--- a/helper/plotting.py
+++ b/helper/plotting.py
@@ -1,4 +1,4 @@
-import ROOT
+import logging
 from io import StringIO
 from typing import Any, Dict, List
 

--- a/helper/plotting.py
+++ b/helper/plotting.py
@@ -149,6 +149,8 @@ def plot_data_mc(
     c.SetLeftMargin(0.16)
     c.SetBottomMargin(0.12)
 
+    c.SetLogy()
+
     ROOT.gStyle.SetOptStat(0)  # set off of the histogram statistics box
     ROOT.gStyle.SetTextFont(
         42
@@ -317,6 +319,7 @@ def plot_data_mc_ratio(
     pad1 = ROOT.TPad("pad1", "pad1", 0, 0.25, 1, 1.0)
     pad1.SetRightMargin(0.05)
     pad1.SetLeftMargin(0.16)
+    pad1.SetLogy()
     pad1.Draw()
     # Lower ratio plot is pad2
     c.cd()
@@ -368,6 +371,8 @@ def plot_data_mc_ratio(
         hist_str = "reduced"
     else:
         hist_str = "full"
+
+    c.SetLogy()
 
     out = StringIO()
     with pipes(stdout=out, stderr=STDOUT):

--- a/helper/plotting.py
+++ b/helper/plotting.py
@@ -17,6 +17,7 @@ def plot_FFs(
     category: Dict[str, str],
     output_path: str,
     logger: str,
+    draw_option: str = "fit",
 ) -> None:
     """
     Function which produces a fake factor plot.
@@ -82,7 +83,7 @@ def plot_FFs(
     legend.SetTextAlign(12)
     legend.AddEntry(ff_ratio, "measured", "lep")
     for unc in uncertainties:
-        legend.AddEntry(uncertainties[unc], gd.label_dict[unc], "fl")
+        legend.AddEntry(uncertainties[unc], gd.label_dict[unc][draw_option], "fl")
     legend.Draw("SAME")
 
     text = ROOT.TLatex()

--- a/helper/plotting.py
+++ b/helper/plotting.py
@@ -1,8 +1,9 @@
 import ROOT
 from io import StringIO
-from wurlitzer import pipes, STDOUT
-import logging
 from typing import Any, Dict, List
+
+import ROOT
+from wurlitzer import STDOUT, pipes
 
 import configs.general_definitions as gd
 

--- a/helper/weights.py
+++ b/helper/weights.py
@@ -1,5 +1,5 @@
 import array
-from typing import Dict, Any, Union, List
+from typing import Any, Dict, List, Union
 
 
 def gen_weight(rdf: Any, sample_info: Dict[str, str]) -> Any:

--- a/preselection.py
+++ b/preselection.py
@@ -252,6 +252,11 @@ if __name__ == "__main__":
         for wp in tau_vs_jet_wgt_wps:
             output_features.append("id_wgt_tau_vsJet_" + wp + "_1")
 
+    if "additional_features" in config:
+        for item in config["additional_features"]:
+            if item not in output_features:
+                output_features.append(item)
+
     # going through all wanted processes and run the preselection function with a pool of 8 workers
     args_list = [(process, config, int(args.ncores)) for process in config["processes"]]
 

--- a/preselection.py
+++ b/preselection.py
@@ -4,6 +4,7 @@ Script for preprocessing n-tuples for the fake factor calculation
 
 import os
 import argparse
+import ipdb.stdout
 import yaml
 import json
 import multiprocessing
@@ -238,8 +239,8 @@ if __name__ == "__main__":
     # get needed features for fake factor calculation
     output_features = gd.output_features[config["analysis"]][config["channel"]]
 
-    tau_vs_jet_wps = ["VVVLoose", "Medium", "Tight"]
-    tau_vs_jet_wgt_wps = ["Medium", "Tight"]
+    tau_vs_jet_wps = ["VVVLoose", "Medium", "Tight"] if not config.get("wps") else config["wps"]["tau_vs_jet"]["wp"]
+    tau_vs_jet_wgt_wps = ["Medium", "Tight"] if not config.get("wps") else config["wps"]["tau_vs_jet"]["wgt"]
     for wp in tau_vs_jet_wps:
         output_features.append("id_tau_vsJet_" + wp + "_2")
     for wp in tau_vs_jet_wgt_wps:


### PR DESCRIPTION
Introducing the optional fit_option to fake_factors_{channel}.yaml bening able to specify

* "poly_1" (default) fit
* ["poly_N1", "poly_N2"] best fit result based on chi2/ndf and whether or not the nominal function is > 0 in the fitting range
* "bin_wise" (not implemented yet)

Removing "slope_unc_{up,down}" and "normalization_unc_{up,down}" and replacing them with "unc_{up,down}" that is derived from the fit result using the full covariance matrix. The corresponding expression is propagated to the correction libs.

* [ ] Check if Correction creation is affected by this change
* [ ] Adding documentations to functions introduced in `fitting_helper.py`

Also added minor improvements where additional quantities can be included at the preselection step.