### PR TITLE
Introducing version tags for corrections

### DIFF
--- a/docs/corrections.md
+++ b/docs/corrections.md
@@ -15,6 +15,7 @@ The expected input folder structure is workdir/WORKDIR_NAME/ERA/fake_factors/CHA
   parameter | type | description
   ---|---|---
   `channel` | `string` | tau pair decay channels ("et", "mt", "tt")
+  `correction_tag` | `string` | this parameter can be set to save a correction calculation run to a separate folder, this allow to have multiple correction calulations for a single fake factor calculation. The default folder is `default`.
 
 In `target_processes` the processes for which FF corrections should be calculated (normally for QCD, Wjets, ttbar) are defined.
 

--- a/ff_corrections.py
+++ b/ff_corrections.py
@@ -405,7 +405,7 @@ def run_non_closure_correction_for_DRtoSR(
             var_dependences=var_dependences,
             for_DRtoSR=True,
             logger=f"ff_corrections.{process}.DR_SR",
-            correction_tag=corr_config["correction_tag"],
+            correction_tag=corr_config.get("correction_tag", "default"),
         )
 
         corrections.update(
@@ -478,7 +478,7 @@ def run_correction(
             var_dependences=var_dependences,
             for_DRtoSR=corr_config["target_processes"][process]["DR_SR"].get("use_orthogonal_fake_factors", True),
             logger=f"ff_corrections.{process}",
-            correction_tag=corr_config["correction_tag"],
+            correction_tag=corr_config.get("correction_tag", "default"),
         )
 
         corr_evaluators = []
@@ -494,7 +494,7 @@ def run_correction(
             corr_evaluators.append(
                 FakeFactorCorrectionEvaluator.loading_from_file(
                     config=config,
-                    correction_tag=corr_config["correction_tag"],
+                    correction_tag=corr_config.get("correction_tag", "default"),
                     process=process,
                     corr_variable=non_closure_corr_vars_DR_SR,
                     for_DRtoSR=True,
@@ -582,7 +582,7 @@ def run_correction(
             var_dependences=var_dependences,
             for_DRtoSR=False,
             logger=f"ff_corrections.{process}",
-            correction_tag=corr_config["correction_tag"],
+            correction_tag=corr_config.get("correction_tag", "default"),
         )
 
         corrections[process].update(
@@ -618,7 +618,7 @@ if __name__ == "__main__":
 
     func.RuntimeVariables.INPUT_FILE_PATH = os.path.join(config["output_path"], config["era"], config["channel"])
 
-    save_path = os.path.join(workdir_path, "corrections", corr_config["correction_tag"], config["channel"])
+    save_path = os.path.join(workdir_path, "corrections", corr_config.get("correction_tag", "default"), config["channel"])
     func.check_path(path=os.path.join(os.getcwd(), save_path))
 
     with open(save_path + "/config.yaml", "w") as config_file:

--- a/ff_corrections.py
+++ b/ff_corrections.py
@@ -405,6 +405,7 @@ def run_non_closure_correction_for_DRtoSR(
             var_dependences=var_dependences,
             for_DRtoSR=True,
             logger=f"ff_corrections.{process}.DR_SR",
+            correction_tag=corr_config["correction_tag"],
         )
 
         corrections.update(
@@ -477,6 +478,7 @@ def run_correction(
             var_dependences=var_dependences,
             for_DRtoSR=corr_config["target_processes"][process]["DR_SR"].get("use_orthogonal_fake_factors", True),
             logger=f"ff_corrections.{process}",
+            correction_tag=corr_config["correction_tag"],
         )
 
         corr_evaluators = []
@@ -492,6 +494,7 @@ def run_correction(
             corr_evaluators.append(
                 FakeFactorCorrectionEvaluator.loading_from_file(
                     config=config,
+                    correction_tag=corr_config["correction_tag"],
                     process=process,
                     corr_variable=non_closure_corr_vars_DR_SR,
                     for_DRtoSR=True,
@@ -579,6 +582,7 @@ def run_correction(
             var_dependences=var_dependences,
             for_DRtoSR=False,
             logger=f"ff_corrections.{process}",
+            correction_tag=corr_config["correction_tag"],
         )
 
         corrections[process].update(
@@ -614,7 +618,7 @@ if __name__ == "__main__":
 
     func.RuntimeVariables.INPUT_FILE_PATH = os.path.join(config["output_path"], config["era"], config["channel"])
 
-    save_path = os.path.join(workdir_path, "corrections", config["channel"])
+    save_path = os.path.join(workdir_path, "corrections", corr_config["correction_tag"], config["channel"])
     func.check_path(path=os.path.join(os.getcwd(), save_path))
 
     with open(save_path + "/config.yaml", "w") as config_file:

--- a/helper/correctionlib_json.py
+++ b/helper/correctionlib_json.py
@@ -748,7 +748,7 @@ def generate_correction_corrlib(
 
     if output_path is not None:
         base_filepath = os.path.join(output_path, f"FF_corrections_{config['channel']}")
-        suffix = "_for_DRtoSR" if for_DRtoSR else ""
+        suffix = "_for_DRtoSR" if for_DRtoSR else f"_{config['correction_tag']}"
         write_json(f"{base_filepath}{suffix}.json", cset)
         write_json(f"{base_filepath}{suffix}.json.gz", cset)
 

--- a/helper/correctionlib_json.py
+++ b/helper/correctionlib_json.py
@@ -748,7 +748,7 @@ def generate_correction_corrlib(
 
     if output_path is not None:
         base_filepath = os.path.join(output_path, f"FF_corrections_{config['channel']}")
-        suffix = "_for_DRtoSR" if for_DRtoSR else f"_{config['correction_tag']}"
+        suffix = "_for_DRtoSR" if for_DRtoSR else f"_{config.get('correction_tag', 'default')}"
         write_json(f"{base_filepath}{suffix}.json", cset)
         write_json(f"{base_filepath}{suffix}.json.gz", cset)
 

--- a/helper/ff_evaluators.py
+++ b/helper/ff_evaluators.py
@@ -28,6 +28,7 @@ class FakeFactorEvaluator:
         var_dependences: List[str],
         for_DRtoSR: bool,
         logger: str,
+        correction_tag: str = "",
     ) -> "FakeFactorEvaluator":
         log = logging.getLogger(logger)
 
@@ -38,6 +39,7 @@ class FakeFactorEvaluator:
             path = os.path.join(
                 *directories,
                 "corrections",
+                correction_tag,
                 f"{config['channel']}",
                 f"fake_factors_{config['channel']}_for_corrections.json",
             )
@@ -151,6 +153,7 @@ class FakeFactorCorrectionEvaluator:
     def loading_from_file(
         cls,
         config: Dict[str, Union[str, Dict, List]],
+        correction_tag: str,
         process: str,
         corr_variable: Union[str, Tuple[str, ...]],
         for_DRtoSR: bool,
@@ -162,11 +165,12 @@ class FakeFactorCorrectionEvaluator:
         directories = ["workdir", config["workdir_name"], config["era"]]
 
         if not for_DRtoSR:
-            path = os.path.join(*directories, f"FF_corrections_{config['channel']}.json")
+            path = os.path.join(*directories, f"FF_corrections_{config['channel']}_{correction_tag}.json")
         else:
             path = os.path.join(
                 *directories,
                 "corrections",
+                correction_tag,
                 f"{config['channel']}",
                 f"FF_corrections_{config['channel']}_{_for_DRtoSR}.json",
             )
@@ -293,6 +297,7 @@ class DRSRCorrectionEvaluator:
     def loading_from_file(
         cls,
         config: Dict[str, Union[str, Dict, List]],
+        correction_tag: str,
         process: str,
         corr_variable: Union[str, Tuple[str, ...]],
         logger: str,
@@ -312,7 +317,7 @@ class DRSRCorrectionEvaluator:
         log = logging.getLogger(logger)
 
         directories = ["workdir", config["workdir_name"], config["era"]]
-        path = os.path.join(*directories, f"FF_corrections_{config['channel']}.json")
+        path = os.path.join(*directories, f"FF_corrections_{config['channel']}_{correction_tag}.json")
 
         log.info(f"Loading DR_SR correction from file {path} for process {process}")
         correctionlib.register_pyroot_binding()
@@ -608,6 +613,7 @@ def get_fake_factor_evaluator(
     var_dependences: List[str],
     for_DRtoSR: bool,
     logger: str,
+    correction_tag: str = "",
 ) -> Union[FakeFactorEvaluator, ONNXFakeFactorEvaluator]:
     """
     Factory function to decide whether to load the traditional correctionlib JSON
@@ -631,4 +637,4 @@ def get_fake_factor_evaluator(
             return ONNXFakeFactorEvaluator.loading_from_config(nn_config, process, logger)
 
     log.info(f"Using classic correctionlib-based FakeFactorEvaluator for process {process}")
-    return FakeFactorEvaluator.loading_from_file(config, process, var_dependences, for_DRtoSR, logger)
+    return FakeFactorEvaluator.loading_from_file(config, process, var_dependences, for_DRtoSR, logger, correction_tag)

--- a/helper/ff_evaluators.py
+++ b/helper/ff_evaluators.py
@@ -28,7 +28,7 @@ class FakeFactorEvaluator:
         var_dependences: List[str],
         for_DRtoSR: bool,
         logger: str,
-        correction_tag: str = "",
+        correction_tag: str = "default",
     ) -> "FakeFactorEvaluator":
         log = logging.getLogger(logger)
 
@@ -613,7 +613,7 @@ def get_fake_factor_evaluator(
     var_dependences: List[str],
     for_DRtoSR: bool,
     logger: str,
-    correction_tag: str = "",
+    correction_tag: str = "default",
 ) -> Union[FakeFactorEvaluator, ONNXFakeFactorEvaluator]:
     """
     Factory function to decide whether to load the traditional correctionlib JSON


### PR DESCRIPTION
This PR adds the feature request from https://github.com/KIT-CMS/TauFakeFactors/issues/33.

Now for a single fake factor calculation different versions of correction can be calculated. They are defined by the `correction_tag` parameter that should be set in the config for the corrections.

ToDo:

- [x] update documentation